### PR TITLE
Fix tuning script bugs

### DIFF
--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -21,11 +21,13 @@ python autotune.py winograd 1286.mlir --lhs-dims=bmk --rhs-dims=bkn --tile-dims=
 
 # Default values for num_candidates and devices, change it as needed
 DEFAULT_NUM_CANDIDATES = 2048
-DEFAULT_DEVICE_LIST = [1, 3]
+DEFAULT_DEVICE_LIST = [0]
+
 # Default values for max number of workers
 DEFAULT_MAX_CPU_WORKERS = (
-    multiprocessing.cpu_count()
-)  # the actual amount of worker that will be generated = max(min(max_cpu_workers, len(task_list)), 1)
+    multiprocessing.cpu_count()//2 
+)  # the actual amount of worker that will be generated = max(min(max_cpu_workers//2, len(task_list)), 1)
+"""note: Do not use all CPU cores"""
 
 
 def parse_devices(devices_str: str) -> list[int]:
@@ -111,7 +113,7 @@ def setup_logging(args: argparse.Namespace, log_dir: Path) -> Path:
     logging.info(f"Devices: {args.devices}")
     logging.info(f"Number of candidates: {args.num_candidates}")
     logging.info(
-        f"Extra options for tune.py: lhs-dims={args.lhs_dims}, rhs-dims{args.rhs_dims}, tile-dims={args.tile_dims}"
+        f"Extra options for tune.py: lhs-dims={args.lhs_dims}, rhs-dims={args.rhs_dims}, tile-dims={args.tile_dims}"
     )
     logging.info(
         f"Device for Unet candidates: {args.devices[0]}"

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -20,8 +20,8 @@ python autotune.py winograd 1286.mlir --lhs-dims=bmk --rhs-dims=bkn --tile-dims=
 
 
 # Default values for num_candidates and devices, change it as needed
-DEFAULT_NUM_CANDIDATES = 1024
-DEFAULT_DEVICE_LIST = [0]
+DEFAULT_NUM_CANDIDATES = 2048
+DEFAULT_DEVICE_LIST = [1, 3]
 # Default values for max number of workers
 DEFAULT_MAX_CPU_WORKERS = (
     multiprocessing.cpu_count()
@@ -57,7 +57,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--devices",
         type=parse_devices,
-        default=[0],
+        default=DEFAULT_DEVICE_LIST,
         help="Comma-separated list of device IDs (e.g., --devices=0,1). Default: [0]",
     )
     parser.add_argument(
@@ -185,6 +185,8 @@ def generate_candidates(
     args: argparse.Namespace, base_dir: Path
 ) -> tuple[list[Path], Path]:
     """Generate candidate files for tuning. Returns the list of candidate files and the candidates directory."""
+    logging.debug("generate_candidates()")
+
     try:
         shutil.copy("config_prolog.mlir", base_dir / "config_prolog.mlir")
         shutil.copy("config_epilog.mlir", base_dir / "config_epilog.mlir")
@@ -228,6 +230,8 @@ def compile_candidates(
     candidate_dir: Path,
 ) -> tuple[list[Path], Path]:
     """Compile candidate files for tuning and record in candidate_vmfbs.txt. Returns the list of compiled files and the compiled files directory."""
+    logging.debug("compile_candidates()")
+
     task_list = []
     for candidate in candidates:
         if "_config.mlir" not in candidate.name:
@@ -258,6 +262,8 @@ def benchmark_top_candidates(
     compiled_files: list[Path],
 ) -> Path:
     """Benchmark the candidate files and store the top20 results in file (best.log). Return the log file"""
+    logging.debug("benchmark_top_candidates()")
+
     task_list = []
     for compiled_file in compiled_files:
         command = ["./benchmark_dispatch.sh", f"{compiled_file}"]
@@ -302,15 +308,18 @@ def compile_unet_candidates(
     args: argparse.Namespace, base_dir: Path, best_log: Path
 ) -> list[str]:
     """Compile U-Net candidates stored in best.log. Return the list of U-Net candidate files."""
+    logging.debug("compile_unet_candidates()")
+
     task_list = []
     with best_log.open("r") as log_file:
         for line in log_file:
             if "/0.mlir" not in line:
+                input_file = line.strip().split()[2]
                 command = [
                     "./compile_unet_candidate.sh",
                     f"{args.mode}",
-                    f"{args.devices[0]}",
-                ]  # Default use the first gpu from the user input --device list
+                    f"{input_file}",
+                ]
                 task_list.append((args, command))
 
     num_worker = max(min(args.max_cpu_workers, len(task_list)), 1)  # at least 1 worker
@@ -328,6 +337,8 @@ def benchmark_unet(
     args: argparse.Namespace, base_dir: Path, unet_candidates: list[str]
 ) -> None:
     """Benchmark U-Net candidate files and log the results. Return the file path of unet_results.log"""
+    logging.debug("benchmark_unet()")
+
     unet_result_log = base_dir / "unet_results.log"
 
     with unet_result_log.open("w") as log_file:

--- a/tuning/tune.py
+++ b/tuning/tune.py
@@ -237,7 +237,8 @@ def apply_params_mmt(M, N, K, template, configuration: Configuration):
 def apply_params_conv(
     N, OH, OW, OC, FH, FW, IC, template, configuration: Configuration
 ):
-    print(configuration)
+    # print(configuration)
+    tune_logger.info(f"{configuration}")
     extra_config = get_pipeline_config(configuration)
     expr0 = re.compile(
         r"<intrinsic = #iree_gpu.mma_layout<(.+)>, subgroup_m_count = ([0-9]+), subgroup_n_count = ([0-9]+)>"
@@ -291,7 +292,8 @@ def apply_params_conv(
 def apply_params_contract(
     LHS, RHS, RES, tile_dims, template, configuration: Configuration
 ):
-    print(configuration)
+    # print(configuration)
+    tune_logger.info(f"{configuration}")
     extra_config = get_pipeline_config(configuration)
     expr0 = re.compile(
         r"<intrinsic = #iree_gpu.mma_layout<(.+)>, subgroup_m_count = ([0-9]+), subgroup_n_count = ([0-9]+)>"
@@ -324,7 +326,8 @@ def apply_params_contract(
 def apply_params_batch_matmul(
     LHS, RHS, RES, B, M, N, K, tile_dims, template, configuration: Configuration
 ):
-    print(configuration)
+    # print(configuration)
+    tune_logger.info(f"{configuration}")
     extra_config = get_pipeline_config(configuration)
     expr0 = re.compile(
         r"<intrinsic = #iree_gpu.mma_layout<(.+)>, subgroup_m_count = ([0-9]+), subgroup_n_count = ([0-9]+)>"
@@ -568,7 +571,8 @@ def generate_constraints(
 
 
 def generate_solutions(M, N, K):
-    print(M, N, K)
+    # print(M, N, K)
+    tune_logger.info(f"{M},{N},{K}")
     m, n, k = z3.Int("m"), z3.Int("n"), z3.Int("k")
     subgroup_size = z3.Int("subgroup_size")
     intrinsic_mn = z3.Int("intrinsic_mn")
@@ -681,7 +685,8 @@ def tune(
         for i, config in enumerate(generate_solutions(M, N, K)):
             if i >= limit:
                 break
-            print(f"Solution #{i+1}: {config}")
+            # print(f"Solution #{i+1}: {config}")
+            tune_logger.info(f"Solution #{i+1}: {config}")
             new_mlir, embeddable_tuning = apply_params_mmt(
                 M, N, K, mlir_template, config
             )
@@ -701,7 +706,8 @@ def tune(
         for i, config in enumerate(generate_solutions(M, N, K)):
             if i >= limit:
                 break
-            print(f"Solution #{i+1}: {config}")
+            # print(f"Solution #{i+1}: {config}")
+            tune_logger.info(f"Solution #{i+1}: {config}")
             new_mlir, embeddable_tuning = apply_params_conv(
                 n, oh, ow, oc, fh, fw, ic, mlir_template, config
             )

--- a/tuning/tune.py
+++ b/tuning/tune.py
@@ -197,7 +197,6 @@ transform.named_sequence @{functionName}(%batch_matmul: !transform.any_op {{tran
 
 
 def apply_params_mmt(M, N, K, template, configuration: Configuration):
-    # print(configuration)
     tune_logger.info(f"{configuration}")
     extra_config = get_pipeline_config(configuration)
     expr0 = re.compile(
@@ -237,7 +236,6 @@ def apply_params_mmt(M, N, K, template, configuration: Configuration):
 def apply_params_conv(
     N, OH, OW, OC, FH, FW, IC, template, configuration: Configuration
 ):
-    # print(configuration)
     tune_logger.info(f"{configuration}")
     extra_config = get_pipeline_config(configuration)
     expr0 = re.compile(
@@ -292,7 +290,6 @@ def apply_params_conv(
 def apply_params_contract(
     LHS, RHS, RES, tile_dims, template, configuration: Configuration
 ):
-    # print(configuration)
     tune_logger.info(f"{configuration}")
     extra_config = get_pipeline_config(configuration)
     expr0 = re.compile(
@@ -326,7 +323,6 @@ def apply_params_contract(
 def apply_params_batch_matmul(
     LHS, RHS, RES, B, M, N, K, tile_dims, template, configuration: Configuration
 ):
-    # print(configuration)
     tune_logger.info(f"{configuration}")
     extra_config = get_pipeline_config(configuration)
     expr0 = re.compile(
@@ -571,7 +567,6 @@ def generate_constraints(
 
 
 def generate_solutions(M, N, K):
-    # print(M, N, K)
     tune_logger.info(f"{M},{N},{K}")
     m, n, k = z3.Int("m"), z3.Int("n"), z3.Int("k")
     subgroup_size = z3.Int("subgroup_size")
@@ -685,7 +680,6 @@ def tune(
         for i, config in enumerate(generate_solutions(M, N, K)):
             if i >= limit:
                 break
-            # print(f"Solution #{i+1}: {config}")
             tune_logger.info(f"Solution #{i+1}: {config}")
             new_mlir, embeddable_tuning = apply_params_mmt(
                 M, N, K, mlir_template, config
@@ -706,7 +700,6 @@ def tune(
         for i, config in enumerate(generate_solutions(M, N, K)):
             if i >= limit:
                 break
-            # print(f"Solution #{i+1}: {config}")
             tune_logger.info(f"Solution #{i+1}: {config}")
             new_mlir, embeddable_tuning = apply_params_conv(
                 n, oh, ow, oc, fh, fw, ic, mlir_template, config
@@ -730,7 +723,6 @@ def tune(
         for i, config in enumerate(generate_solutions(M, N, K0)):
             if i >= limit:
                 break
-            # print(f'Solution #{i+1}: {config}')
             new_mlir = apply_params_contract(
                 LHS, RHS, RES, tile_dims, mlir_template, config
             )
@@ -754,7 +746,6 @@ def tune(
         for i, config in enumerate(generate_solutions(M, N, K0)):
             if i >= limit:
                 break
-            # print(f'Solution #{i+1}: {config}')
             new_mlir, embeddable_tuning = apply_params_batch_matmul(
                 LHS, RHS, RES, B, M, N, K0, tile_dims, mlir_template, config
             )


### PR DESCRIPTION
autotune.py:
1. Changed the third input for shell command ./compile_unet_candidate.sh from device_id to input_mlir_file in compile_unet_candidates()
2. Fixed the bug where the global constant DEFAULT_DEVICE_LIST wasn't applied to default value of --device 
3. Add logging.debug(<function_name>) to each function

tune.py:
1. Replaced the remaining print() with tune_logger.info() 