### PR TITLE
Add candidate tracker and progress bar to autotune.py

### DIFF
--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -250,7 +250,6 @@ def numerical_sort_key(path):
 
 
 def calculate_md5(file_path):
-    """calculate the MD5 hash"""
     md5 = hashlib.md5()
     with open(file_path, 'rb') as f:
         for chunk in iter(lambda: f.read(4096), b''):

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 import re
 import hashlib
 from dataclasses import dataclass
+
 # from typing import Callable
 
 """
@@ -34,6 +35,7 @@ DEFAULT_MAX_CPU_WORKERS = (
 )  # the actual amount of worker that will be generated = max(min(max_cpu_workers//2, len(task_list)), 1)
 """note: Do not use all CPU cores"""
 
+
 @dataclass
 class CandidateTracker:
     candidate_id: int
@@ -46,9 +48,6 @@ class CandidateTracker:
     unet_candidate_path: str = None
     unet_vmfb_hash: str = None
     unet_benchmark_time: float = None
-
-
-
 
 
 def parse_devices(devices_str: str) -> list[int]:
@@ -241,21 +240,21 @@ def numerical_sort_key(path: Path) -> tuple[int, str]:
     Order: 0 | 0_a | 0_b | 1 | 1_a | 2
     """
     # Extract the numeric part at the start of the filename
-    match = re.match(r'(\d+)', path.stem)
+    match = re.match(r"(\d+)", path.stem)
     if match:
         numeric_part = int(match.group(1))
         # The rest of the filename after the numeric part
-        remaining_part = path.stem[len(match.group(0)):]
+        remaining_part = path.stem[len(match.group(0)) :]
     else:
-        numeric_part = float('inf')
+        numeric_part = float("inf")
         remaining_part = path.stem
     return (numeric_part, remaining_part)
 
 
 def calculate_md5(file_path: str) -> str:
     md5 = hashlib.md5()
-    with open(file_path, 'rb') as f:
-        for chunk in iter(lambda: f.read(4096), b''):
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
             md5.update(chunk)
     return md5.hexdigest()
 
@@ -303,10 +302,12 @@ def generate_candidates(
     for mlir in mlirs:
         if "_config.mlir" not in mlir.name:
             candidates.append(mlir)
-            new_candidate  = CandidateTracker(candidate_id=mlir.stem, mlir_path=mlir)
+            new_candidate = CandidateTracker(candidate_id=mlir.stem, mlir_path=mlir)
             candidate_trackers.append(new_candidate)
         else:
-            candidate_trackers[int(mlir.stem.split("_config")[0])].mlir_config_path = mlir
+            candidate_trackers[int(mlir.stem.split("_config")[0])].mlir_config_path = (
+                mlir
+            )
 
     return candidates, candidates_dir
 
@@ -316,7 +317,7 @@ def compile_candidates(
     base_dir: Path,
     candidates: list[Path],
     candidate_dir: Path,
-    candidate_trackers: CandidateTracker
+    candidate_trackers: CandidateTracker,
 ) -> tuple[list[Path], Path]:
     """Compile candidate files for tuning and record in candidate_vmfbs.txt. Returns the list of compiled files and the compiled files directory."""
     logging.debug("compile_candidates()")
@@ -338,7 +339,9 @@ def compile_candidates(
     failed_files = sorted(failed_dir.glob("*.mlir"), key=numerical_sort_key)
 
     logging.info(f"Compiled: {len(compiled_files)} | Failed: {len(failed_files)}")
-    print(f"Total: {len(task_list)} | Compiled: {len(compiled_files)} | Failed: {len(failed_files)}")
+    print(
+        f"Total: {len(task_list)} | Compiled: {len(compiled_files)} | Failed: {len(failed_files)}"
+    )
 
     # Write compiled files to candidate_vmfbs.txt
     candidate_vmfbs_file = base_dir / "candidate_vmfbs.txt"
@@ -363,7 +366,7 @@ def benchmark_top_candidates(
     base_dir: Path,
     candidates_dir: Path,
     compiled_files: list[Path],
-    candidate_trackers: CandidateTracker
+    candidate_trackers: CandidateTracker,
 ) -> Path:
     """Benchmark the candidate files and store the top20 results in file (best.log). Return the log file"""
     logging.debug("benchmark_top_candidates()")
@@ -396,7 +399,9 @@ def benchmark_top_candidates(
                 parts = line.split()
 
                 # Update candidate tracker
-                candidate_trackers[int(parts[0])].first_benchmark_time = float(parts[-1])
+                candidate_trackers[int(parts[0])].first_benchmark_time = float(
+                    parts[-1]
+                )
 
                 best_results.append(
                     (
@@ -416,7 +421,10 @@ def benchmark_top_candidates(
 
 
 def compile_unet_candidates(
-    args: argparse.Namespace, base_dir: Path, best_log: Path, candidate_trackers: CandidateTracker
+    args: argparse.Namespace,
+    base_dir: Path,
+    best_log: Path,
+    candidate_trackers: CandidateTracker,
 ) -> list[str]:
     """Compile U-Net candidates stored in best.log. Return the list of U-Net candidate files."""
     logging.debug("compile_unet_candidates()")
@@ -445,23 +453,26 @@ def compile_unet_candidates(
     for unet_candidate in unet_candidates:
         index = int(unet_candidate.stem.split("_")[-1])
         candidate_trackers[index].unet_candidate_path = unet_candidate
-        candidate_trackers[index].unet_vmfb_hash = calculate_md5(candidate_trackers[index].unet_candidate_path)
+        candidate_trackers[index].unet_vmfb_hash = calculate_md5(
+            candidate_trackers[index].unet_candidate_path
+        )
 
     return unet_candidates
 
 
 def benchmark_unet(
-    args: argparse.Namespace, base_dir: Path, unet_candidates: list[str], candidate_trackers: CandidateTracker
+    args: argparse.Namespace,
+    base_dir: Path,
+    unet_candidates: list[str],
+    candidate_trackers: CandidateTracker,
 ) -> None:
     """Benchmark U-Net candidate files and log the results. Return the file path of unet_results.log"""
     logging.debug("benchmark_unet()")
 
-    unet_candidates = (
-        ["unet_baseline.vmfb"] + unet_candidates + ["unet_baseline.vmfb"]
-    )
+    unet_candidates = ["unet_baseline.vmfb"] + unet_candidates + ["unet_baseline.vmfb"]
     # Update candidate tracker
     candidate_trackers[0].unet_candidate_path = "unet_baseline.vmfb"
-    
+
     unet_result_log = base_dir / "unet_results.log"
 
     with unet_result_log.open("w") as log_file:
@@ -479,11 +490,21 @@ def benchmark_unet(
                     logging.error(f"Failed: {command}")
                 else:
                     # Update candidate tracker
-                    parts = result.stdout.split() # ex. ['Benchmarking:', '/sdxl-scripts/tuning/unet_baseline.vmfb', 'on', 'device', '4', 'BM_main/process_time/real_time_median', '65.3', 'ms', '66.7', 'ms', '5', 'items_per_second=15.3201/s']
-                    if 'unet_baseline.vmfb' in parts[1]:
-                        candidate_trackers[0].unet_benchmark_time = float(parts[6]) if candidate_trackers[0].unet_benchmark_time is None or float(parts[6]) < candidate_trackers[0].unet_benchmark_time else candidate_trackers[0].unet_benchmark_time
+                    parts = (
+                        result.stdout.split()
+                    )  # ex. ['Benchmarking:', '/sdxl-scripts/tuning/unet_baseline.vmfb', 'on', 'device', '4', 'BM_main/process_time/real_time_median', '65.3', 'ms', '66.7', 'ms', '5', 'items_per_second=15.3201/s']
+                    if "unet_baseline.vmfb" in parts[1]:
+                        candidate_trackers[0].unet_benchmark_time = (
+                            float(parts[6])
+                            if candidate_trackers[0].unet_benchmark_time is None
+                            or float(parts[6])
+                            < candidate_trackers[0].unet_benchmark_time
+                            else candidate_trackers[0].unet_benchmark_time
+                        )
                     else:
-                        candidate_trackers[int(parts[1].split("_")[-1].split(".")[0])].unet_benchmark_time = float(parts[6])
+                        candidate_trackers[
+                            int(parts[1].split("_")[-1].split(".")[0])
+                        ].unet_benchmark_time = float(parts[6])
                 time.sleep(10)
                 pbar.update(1)
 
@@ -512,15 +533,21 @@ def main():
     print(f"Compiled files in {compiled_dir}\n")
 
     print("Benchmarking top candidates...")
-    best_log = benchmark_top_candidates(args, base_dir, candidates_dir, compiled_files, candidate_trackers)
+    best_log = benchmark_top_candidates(
+        args, base_dir, candidates_dir, compiled_files, candidate_trackers
+    )
     print(f"Top20 candidates selected and stored in {best_log}\n")
 
     print("Compiling unet candidates...")
-    unet_candidates = compile_unet_candidates(args, base_dir, best_log, candidate_trackers)
+    unet_candidates = compile_unet_candidates(
+        args, base_dir, best_log, candidate_trackers
+    )
     print("Unet candidates compiled\n")
 
     print("Bnechmarking unet candidates...")
-    unet_result_log = benchmark_unet(args, base_dir, unet_candidates, candidate_trackers)
+    unet_result_log = benchmark_unet(
+        args, base_dir, unet_candidates, candidate_trackers
+    )
     print(f"Done, stored unet result in {unet_result_log}\n")
 
     print("Check the detailed log in:")

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -26,7 +26,7 @@ DEFAULT_DEVICE_LIST = [0]
 
 # Default values for max number of workers
 DEFAULT_MAX_CPU_WORKERS = (
-    multiprocessing.cpu_count()//2 
+    multiprocessing.cpu_count() // 2
 )  # the actual amount of worker that will be generated = max(min(max_cpu_workers//2, len(task_list)), 1)
 """note: Do not use all CPU cores"""
 
@@ -139,7 +139,9 @@ def create_worker_context_queue(device_ids: list[int]) -> multiprocessing.Queue:
     return worker_contexts_queue
 
 
-def worker_run_command_with_device_id(task_tuple: tuple[argparse.Namespace, str, bool]) -> subprocess.CompletedProcess:
+def worker_run_command_with_device_id(
+    task_tuple: tuple[argparse.Namespace, str, bool]
+) -> subprocess.CompletedProcess:
     """worker add its device_id to the command for ./compile_unet_candidate.sh, return the run_command() result"""
     args, command, check = task_tuple
     command.append(str(device_id))
@@ -183,14 +185,24 @@ def run_command(
             raise
 
 
-def run_command_wrapper(task_tuple: tuple[argparse.Namespace, str, bool]) -> subprocess.CompletedProcess:
-    '''pool.imap_unordered can't iterate an iterable of iterables input, this function helps dividing arguments'''
+def run_command_wrapper(
+    task_tuple: tuple[argparse.Namespace, str, bool]
+) -> subprocess.CompletedProcess:
+    """pool.imap_unordered can't iterate an iterable of iterables input, this function helps dividing arguments"""
     args, command, check = task_tuple
     return run_command(args, command, check)
 
 
-def multiprocess_progress_wrapper(num_worker: int, task_list: list, function, initializer: callable = None, initializer_inputs = None) -> list[subprocess.CompletedProcess]:
-    '''Wrapper of multiprocessing pool and progress bar'''
+def multiprocess_progress_wrapper(
+    num_worker: int,
+    task_list: list,
+    function,
+    initializer: callable = None,
+    initializer_inputs=None,
+) -> list[subprocess.CompletedProcess]:
+    """Wrapper of multiprocessing pool and progress bar"""
+    print(task_list)
+    breakpoint()
     results = []
     # Create a multiprocessing pool
     with multiprocessing.Pool(
@@ -264,7 +276,9 @@ def compile_candidates(
             task_list.append((args, command, check))
 
     num_worker = max(min(args.max_cpu_workers, len(task_list)), 1)  # at least 1 worker
-    multiprocess_progress_wrapper(num_worker=num_worker, task_list=task_list, function=run_command_wrapper)
+    multiprocess_progress_wrapper(
+        num_worker=num_worker, task_list=task_list, function=run_command_wrapper
+    )
 
     compiled_dir = candidate_dir / "compiled"
     compiled_files = sorted(compiled_dir.glob("*.vmfb"))
@@ -294,7 +308,13 @@ def benchmark_top_candidates(
         task_list.append((args, command, check))
 
     worker_context_queue = create_worker_context_queue(args.devices)
-    results = multiprocess_progress_wrapper(num_worker=len(args.devices), task_list=task_list, function=worker_run_command_with_device_id, initializer=init_worker_context, initializer_inputs=(worker_context_queue,))
+    results = multiprocess_progress_wrapper(
+        num_worker=len(args.devices),
+        task_list=task_list,
+        function=worker_run_command_with_device_id,
+        initializer=init_worker_context,
+        initializer_inputs=(worker_context_queue,),
+    )
 
     benchmark_results = [result.stdout for result in results]
 
@@ -344,7 +364,9 @@ def compile_unet_candidates(
                 task_list.append((args, command, check))
 
     num_worker = max(min(args.max_cpu_workers, len(task_list)), 1)  # at least 1 worker
-    multiprocess_progress_wrapper(num_worker=num_worker, task_list=task_list, function=run_command_wrapper)
+    multiprocess_progress_wrapper(
+        num_worker=num_worker, task_list=task_list, function=run_command_wrapper
+    )
 
     unet_candidates = (
         ["unet_baseline.vmfb"] + list(base_dir.glob("*.vmfb")) + ["unet_baseline.vmfb"]
@@ -383,9 +405,9 @@ def benchmark_unet(
 def main():
     args = parse_arguments()
 
-    base_dir = Path(f"tuning_{datetime.now().strftime('%Y_%m_%d_%H_%M')}")
+    base_dir = Path(f"tZRYuning_{datetime.now().strftime('%Y_%m_%d_%H_%M')}")
     base_dir.mkdir(parents=True, exist_ok=True)
-    
+
     print("Setup logging\n")
     log_file_path = setup_logging(args, log_dir=base_dir)
 

--- a/tuning/benchmark_dispatch.sh
+++ b/tuning/benchmark_dispatch.sh
@@ -7,7 +7,7 @@ readonly DIR="$(dirname "$INPUT")"
 readonly DEVICE="$2"
 shift 2
 
-mkdir -p "${DIR}/failed"
+mkdir -p "${DIR}/benchmark_failed"
 readonly NAME="$(basename "$INPUT" .mlir)"
 
 # printf "Benchmarking $(basename ${INPUT}) on ${DEVICE}\n"

--- a/tuning/tune.py
+++ b/tuning/tune.py
@@ -8,9 +8,12 @@ import logging
 import re
 import z3
 from dataclasses import asdict, dataclass
-from os import mkdir, path
+from os import mkdir, path, makedirs
 from textwrap import indent
 
+'''
+Usage: ./tune.py 121.mlir -o "tuning/candidates" -l 1024 --lhs-dims=mk --rhs-dims=nk --tile-dims=mnk
+'''
 
 tune_logger = logging.getLogger("tune")
 
@@ -652,7 +655,9 @@ def tune(
 
     if output is None:
         output = get_default_output_dir()
-    mkdir(str(output))
+
+    # Create the directory if it does not exist    
+    makedirs(str(output), exist_ok=True)
 
     tune_logger.debug(f"Output directory {output}")
     tune_logger.debug(f"Processing {input_file}")


### PR DESCRIPTION
autotune.py: 
1. Added dataclass `CandidateTracker`
2. Added progress bar for all candidates processing functions, excluding `generate_candidates()`

tune.py:
1. Fixed incompatibilities with `autotune.sh` (directory existed issue)

benchmark_dispatch.sh:
1. Edited a dir name (`compiled/failed` -> `compiled/benchmark_failed`)