### PR TITLE
Add new constraints for .mlir candidates generator

### DIFF
--- a/tuning/test_tune.py
+++ b/tuning/test_tune.py
@@ -127,14 +127,16 @@ def test_get_shapes_batch_matmul():
 
 def test_generate_solutions():
     M, N, K = 2048, 3840, 1280
+    problem_size = tune.ProblemSize(M, N, K, -1, 16, -1, tune.DispatchKind.mmt)
     configs = None
-    configs = tune.generate_solutions(M, N, K)
+    configs = tune.generate_solutions(problem_size)
     assert configs is not None
 
 
 def test_generate_constraints_valid_input():
     # Define input parameters as z3 Ints
     M, N, K = 256, 384, 32
+    problem_size = tune.ProblemSize(M, N, K, -1, 16, -1, tune.DispatchKind.mmt)
     m, n, k = tune.z3.Int("m"), tune.z3.Int("n"), tune.z3.Int("k")
     subgroup_size = tune.z3.Int("subgroup_size")
     intrinsic_mn = tune.z3.Int("intrinsic_mn")
@@ -145,7 +147,7 @@ def test_generate_constraints_valid_input():
     waves_per_eu = tune.z3.Int("waves_per_eu")
 
     constraints = tune.generate_constraints(
-        [M, N, K],
+        problem_size,
         [m, n, k],
         subgroup_size,
         [intrinsic_mn, intrinsic_k],
@@ -165,6 +167,7 @@ def test_generate_constraints_valid_input():
 def test_generate_constraints_invalid_input():
     # Define input parameters that should lead to unsatisfiable constraints
     M, N, K = 256, 384, 32
+    problem_size = tune.ProblemSize(M, N, K, -1, 16, -1, tune.DispatchKind.mmt)
     m, n, k = tune.z3.Int("m"), tune.z3.Int("n"), tune.z3.Int("k")
     subgroup_size = tune.z3.Int("subgroup_size")
     intrinsic_mn = tune.z3.Int("intrinsic_mn")
@@ -175,7 +178,7 @@ def test_generate_constraints_invalid_input():
     waves_per_eu = tune.z3.Int("waves_per_eu")
 
     constraints = tune.generate_constraints(
-        [M, N, K],
+        problem_size,
         [m, n, k],
         subgroup_size,
         [intrinsic_mn, intrinsic_k],

--- a/tuning/tune.py
+++ b/tuning/tune.py
@@ -591,9 +591,9 @@ def generate_constraints(
     constraints += [wg_k == intrinsic_k * subgroup_k_tile_count]
     constraints += [inner_lhs_dim_size == wg_k]
     if problem_size.dispatch_kind == DispatchKind.mmt:
-        constraints += [inner_rhs_dim_size == wg_n]
-    else:
         constraints += [inner_rhs_dim_size == wg_k]
+    else:
+        constraints += [inner_rhs_dim_size == wg_n]
     constraints += [kMaxVectorLoadBitWidth == 128]
     constraints += [elems_per_thread == kMaxVectorLoadBitWidth / problem_size.rhs_bw]
     constraints += [wg_threads == subgroup_m_count * subgroup_n_count * subgroup_size]
@@ -759,6 +759,7 @@ def tune(
 
     mlir_module = parse_mlir(mlir_text)
     walk_result = walk_mlir_op(mlir_module)
+    walk_result.dispatch_kind = DispatchKind.mmt
     assert walk_result.dispatch_kind != None
 
     # Save the input file as the first candidate.

--- a/tuning/tune.py
+++ b/tuning/tune.py
@@ -384,11 +384,13 @@ def apply_params_batch_matmul(
 def get_shape_dims(shape_str):
     return [int(x) for x in shape_str.split("x")[:-1]]
 
+
 def get_bit_width() -> tuple[int, int, int]:
     lhs_type_bit_width = -1
     rhs_type_bit_width = 16
     output_type_bit_width = -1
     return (lhs_type_bit_width, rhs_type_bit_width, output_type_bit_width)
+
 
 def get_shapes_mmt(template):
     for line in template:
@@ -586,19 +588,25 @@ def generate_constraints(
     elems_per_thread = z3.Int("elems_per_thread")
     wg_threads = z3.Int("wg_threads")
     constraints += [wg_n == intrinsic_mn * subgroup_n_tile_count * subgroup_n_count]
-    constraints += [wg_k == intrinsic_k * subgroup_k_tile_count ]
+    constraints += [wg_k == intrinsic_k * subgroup_k_tile_count]
     constraints += [inner_lhs_dim_size == wg_k]
     if problem_size.dispatch_kind == DispatchKind.mmt:
         constraints += [inner_rhs_dim_size == wg_n]
-    else: 
+    else:
         constraints += [inner_rhs_dim_size == wg_k]
     constraints += [kMaxVectorLoadBitWidth == 128]
     constraints += [elems_per_thread == kMaxVectorLoadBitWidth / problem_size.rhs_bw]
     constraints += [wg_threads == subgroup_m_count * subgroup_n_count * subgroup_size]
     constraints += [
         z3.And(
-            z3.Or((inner_lhs_dim_size / elems_per_thread) % wg_threads == 0, wg_threads % (inner_lhs_dim_size / elems_per_thread) == 0),
-            z3.Or((inner_rhs_dim_size / elems_per_thread) % wg_threads == 0, wg_threads % (inner_rhs_dim_size / elems_per_thread) == 0),
+            z3.Or(
+                (inner_lhs_dim_size / elems_per_thread) % wg_threads == 0,
+                wg_threads % (inner_lhs_dim_size / elems_per_thread) == 0,
+            ),
+            z3.Or(
+                (inner_rhs_dim_size / elems_per_thread) % wg_threads == 0,
+                wg_threads % (inner_rhs_dim_size / elems_per_thread) == 0,
+            ),
         )
     ]
 
@@ -764,7 +772,9 @@ def tune(
         N = oc
         K = fh * fw * ic
         tune_logger.debug(f"Equivalent matmul shape: [{M}, {N}, {K}]")
-        problem_size = ProblemSize(M, N, K, *get_bit_width(), dispatch_kind=walk_result.dispatch_kind)
+        problem_size = ProblemSize(
+            M, N, K, *get_bit_width(), dispatch_kind=walk_result.dispatch_kind
+        )
 
         for i, config in enumerate(generate_solutions(problem_size)):
             if i >= limit:
@@ -781,7 +791,9 @@ def tune(
     elif walk_result.dispatch_kind == DispatchKind.mmt:
         M, N, K = get_shapes_mmt(mlir_template)
         tune_logger.debug(f"Matmul shape: [{M}, {N}, {K}]")
-        problem_size = ProblemSize(M, N, K, *get_bit_width(), dispatch_kind=walk_result.dispatch_kind)
+        problem_size = ProblemSize(
+            M, N, K, *get_bit_width(), dispatch_kind=walk_result.dispatch_kind
+        )
 
         for i, config in enumerate(generate_solutions(problem_size)):
             if i >= limit:
@@ -806,7 +818,9 @@ def tune(
         K1 = product(val if dim == "k" else 1 for dim, val in zip(rhs_dims, RHS))
         assert K0 == K1
         tune_logger.debug(f"Equivalent matmul shape: [{M}, {N}, {K0}]")
-        problem_size = ProblemSize(M, N, K0, *get_bit_width(), dispatch_kind=walk_result.dispatch_kind)
+        problem_size = ProblemSize(
+            M, N, K0, *get_bit_width(), dispatch_kind=walk_result.dispatch_kind
+        )
 
         for i, config in enumerate(generate_solutions(problem_size)):
             if i >= limit:
@@ -831,7 +845,9 @@ def tune(
         assert B == B0 and B == B1
         assert K0 == K1
         tune_logger.debug(f"Batch matmul shape: {B}x[{M}, {N}, {K0}]")
-        problem_size = ProblemSize(M, N, K0, *get_bit_width(), dispatch_kind=walk_result.dispatch_kind)
+        problem_size = ProblemSize(
+            M, N, K0, *get_bit_width(), dispatch_kind=walk_result.dispatch_kind
+        )
 
         for i, config in enumerate(generate_solutions(problem_size)):
             if i >= limit:

--- a/tuning/tune.py
+++ b/tuning/tune.py
@@ -46,6 +46,17 @@ class OpWalkResult:
     dispatch_kind: DispatchKind = None
 
 
+@dataclass
+class ProblemSize:
+    M: int
+    N: int
+    K: int
+    lhs_bw: int
+    rhs_bw: int
+    out_bw: int
+    dispatch_kind: DispatchKind
+
+
 def read_input_mlir(filename):
     template = f""
     with open(filename, "r") as f:
@@ -373,6 +384,11 @@ def apply_params_batch_matmul(
 def get_shape_dims(shape_str):
     return [int(x) for x in shape_str.split("x")[:-1]]
 
+def get_bit_width() -> tuple[int, int, int]:
+    lhs_type_bit_width = -1
+    rhs_type_bit_width = 16
+    output_type_bit_width = -1
+    return (lhs_type_bit_width, rhs_type_bit_width, output_type_bit_width)
 
 def get_shapes_mmt(template):
     for line in template:
@@ -511,7 +527,7 @@ def is_not_pow2(x, min, max):
 
 
 def generate_constraints(
-    problem_size,
+    problem_size: ProblemSize,
     tile_sizes,
     subgroup_size,
     intrinsic_size,
@@ -520,7 +536,7 @@ def generate_constraints(
     subgroup_n_count,
     waves_per_eu,
 ):
-    M, N, K = problem_size
+    M, N, K = problem_size.M, problem_size.N, problem_size.K
     m, n, k = tile_sizes
     intrinsic_mn, intrinsic_k = intrinsic_size
     wg_x, wg_y, wg_z = workgroup_size
@@ -562,10 +578,35 @@ def generate_constraints(
 
     constraints += [z3.Or(waves_per_eu == 1, waves_per_eu == 2, waves_per_eu == 4)]
 
+    wg_n = z3.Int("wg_n")
+    wg_k = z3.Int("wg_k")
+    inner_lhs_dim_size = z3.Int("inner_lhs_dim_size")
+    inner_rhs_dim_size = z3.Int("inner_rhs_dim_size")
+    kMaxVectorLoadBitWidth = z3.Int("kMaxVectorLoadBitWidth")
+    elems_per_thread = z3.Int("elems_per_thread")
+    wg_threads = z3.Int("wg_threads")
+    constraints += [wg_n == intrinsic_mn * subgroup_n_tile_count * subgroup_n_count]
+    constraints += [wg_k == intrinsic_k * subgroup_k_tile_count ]
+    constraints += [inner_lhs_dim_size == wg_k]
+    if problem_size.dispatch_kind == DispatchKind.mmt:
+        constraints += [inner_rhs_dim_size == wg_n]
+    else: 
+        constraints += [inner_rhs_dim_size == wg_k]
+    constraints += [kMaxVectorLoadBitWidth == 128]
+    constraints += [elems_per_thread == kMaxVectorLoadBitWidth / problem_size.rhs_bw]
+    constraints += [wg_threads == subgroup_m_count * subgroup_n_count * subgroup_size]
+    constraints += [
+        z3.And(
+            z3.Or((inner_lhs_dim_size / elems_per_thread) % wg_threads == 0, wg_threads % (inner_lhs_dim_size / elems_per_thread) == 0),
+            z3.Or((inner_rhs_dim_size / elems_per_thread) % wg_threads == 0, wg_threads % (inner_rhs_dim_size / elems_per_thread) == 0),
+        )
+    ]
+
     return constraints
 
 
-def generate_solutions(M, N, K):
+def generate_solutions(problem_size: ProblemSize):
+    M, N, K = problem_size.M, problem_size.N, problem_size.K
     tune_logger.info(f"{M},{N},{K}")
     m, n, k = z3.Int("m"), z3.Int("n"), z3.Int("k")
     subgroup_size = z3.Int("subgroup_size")
@@ -592,7 +633,7 @@ def generate_solutions(M, N, K):
 
     solver = z3.Solver()
     constraints = generate_constraints(
-        [M, N, K],
+        problem_size,
         [m, n, k],
         subgroup_size,
         [intrinsic_mn, intrinsic_k],
@@ -723,8 +764,9 @@ def tune(
         N = oc
         K = fh * fw * ic
         tune_logger.debug(f"Equivalent matmul shape: [{M}, {N}, {K}]")
+        problem_size = ProblemSize(M, N, K, *get_bit_width(), dispatch_kind=walk_result.dispatch_kind)
 
-        for i, config in enumerate(generate_solutions(M, N, K)):
+        for i, config in enumerate(generate_solutions(problem_size)):
             if i >= limit:
                 break
             tune_logger.info(f"Solution #{i+1}: {config}")
@@ -739,8 +781,9 @@ def tune(
     elif walk_result.dispatch_kind == DispatchKind.mmt:
         M, N, K = get_shapes_mmt(mlir_template)
         tune_logger.debug(f"Matmul shape: [{M}, {N}, {K}]")
+        problem_size = ProblemSize(M, N, K, *get_bit_width(), dispatch_kind=walk_result.dispatch_kind)
 
-        for i, config in enumerate(generate_solutions(M, N, K)):
+        for i, config in enumerate(generate_solutions(problem_size)):
             if i >= limit:
                 break
             tune_logger.info(f"Solution #{i+1}: {config}")
@@ -763,7 +806,9 @@ def tune(
         K1 = product(val if dim == "k" else 1 for dim, val in zip(rhs_dims, RHS))
         assert K0 == K1
         tune_logger.debug(f"Equivalent matmul shape: [{M}, {N}, {K0}]")
-        for i, config in enumerate(generate_solutions(M, N, K0)):
+        problem_size = ProblemSize(M, N, K0, *get_bit_width(), dispatch_kind=walk_result.dispatch_kind)
+
+        for i, config in enumerate(generate_solutions(problem_size)):
             if i >= limit:
                 break
             new_mlir = apply_params_contract(
@@ -786,7 +831,9 @@ def tune(
         assert B == B0 and B == B1
         assert K0 == K1
         tune_logger.debug(f"Batch matmul shape: {B}x[{M}, {N}, {K0}]")
-        for i, config in enumerate(generate_solutions(M, N, K0)):
+        problem_size = ProblemSize(M, N, K0, *get_bit_width(), dispatch_kind=walk_result.dispatch_kind)
+
+        for i, config in enumerate(generate_solutions(problem_size)):
             if i >= limit:
                 break
             new_mlir, embeddable_tuning = apply_params_batch_matmul(

--- a/tuning/tune.py
+++ b/tuning/tune.py
@@ -521,11 +521,11 @@ def get_shapes_batch_matmul(template):
 
 
 def is_pow2(x, min, max):
-    return z3.Or(list(x == 2**i for i in range(min, max + 1)))
+    return z3.Or(list(x == 2 ** i for i in range(min, max + 1)))
 
 
 def is_not_pow2(x, min, max):
-    return z3.And(list(x != 2**i for i in range(min, max + 1)))
+    return z3.And(list(x != 2 ** i for i in range(min, max + 1)))
 
 
 def generate_constraints(


### PR DESCRIPTION
Fix issue in conv generator: missing verifier in vector distribution.
Reference PR: [Stan's PR](https://github.com/iree-org/iree/commit/52b21f8274f7e62d7c44e4c8b7b2147a00016bc0#diff-af08c7d497f2c9a2062fb9ff890f894e3fd5071476d9198b1422edcedb13bdb5R67-R72)

Create a new dataclass `ProblemSize` and move `M` `N` `K` under it

Update pytest for functions taking `problem_size` as input