### PR TITLE
Update compile-unet-base.sh path in tuner

### DIFF
--- a/tuning/compile_unet_candidate.sh
+++ b/tuning/compile_unet_candidate.sh
@@ -10,7 +10,7 @@ shift 2
 readonly BASE_DIR="$(dirname "${INPUT}")"
 readonly CANDIDATE="$(basename "${INPUT}" _spec.mlir)"
 
-timeout 180s "${SCRIPT_DIR}/../compile-unet-base.sh" "${SCRIPT_DIR}/tools/iree-compile" gfx942 \
+timeout 180s "${SCRIPT_DIR}/../fp16-model/compile-unet-base.sh" "${SCRIPT_DIR}/tools/iree-compile" gfx942 \
   "$MODE" \
   "$INPUT" \
   "${SCRIPT_DIR}/unet.mlir" \

--- a/tuning/unet.sh
+++ b/tuning/unet.sh
@@ -7,7 +7,7 @@ readonly MODE="$1"
 readonly INPUT="$(realpath "$2")"
 shift 2
 
-"${SCRIPT_DIR}/../compile-unet-base.sh" "${SCRIPT_DIR}/tools/iree-compile" gfx942 "$MODE" \
+"${SCRIPT_DIR}/../fp16-model/compile-unet-base.sh" "${SCRIPT_DIR}/tools/iree-compile" gfx942 "$MODE" \
   "${SCRIPT_DIR}/config.mlir" \
   "$INPUT" \
   "$@"


### PR DESCRIPTION
compile-unet-base.sh was moved under `fp16-model` dir in new commits, update it to the correct path in `unet.sh` and `compile_unet_candidate.sh`.