### PR TITLE
[tuner] Track input problem size and element types

### DIFF
--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -337,7 +337,7 @@ def find_collisions(
 
 
 def load_pickle(file_path: Path) -> list[any]:
-    handle_error(condition=(not file_path.exists()), msg=f"Configuration file not found: {e}", error_type=FileNotFoundError)
+    handle_error(condition=(not file_path.exists()), msg=f"Configuration file not found", error_type=FileNotFoundError)
     with open(file_path, "rb") as file:
         loaded_array = pickle.load(file)
     return loaded_array

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -56,7 +56,11 @@ def parse_devices(devices_str: str) -> list[int]:
         devices = [int(device.strip()) for device in devices_str.split(",")]
         return devices
     except ValueError as e:
-        handle_error(condition=True, msg=f"Invalid device list: {devices_str}. Error: {e}", error_type=argparse.ArgumentTypeError)
+        handle_error(
+            condition=True,
+            msg=f"Invalid device list: {devices_str}. Error: {e}",
+            error_type=argparse.ArgumentTypeError,
+        )
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -170,7 +174,7 @@ def handle_error(
     msg: str,
     level: int = logging.ERROR,
     error_type: Type[BaseException] = Exception,
-    exit_program: bool = False
+    exit_program: bool = False,
 ) -> None:
     """Handles errors with logging and optional program exit"""
     if not condition:
@@ -357,7 +361,11 @@ def generate_candidates(
         shutil.copy("config_prolog.mlir", base_dir / "config_prolog.mlir")
         shutil.copy("config_epilog.mlir", base_dir / "config_epilog.mlir")
     except FileNotFoundError as e:
-        handle_error(condition=True, msg=f"Configuration file not found: {e}", error_type=FileNotFoundError)
+        handle_error(
+            condition=True,
+            msg=f"Configuration file not found: {e}",
+            error_type=FileNotFoundError,
+        )
 
     template_mlir = base_dir / "template.mlir"
     candidates_dir = base_dir / "candidates"
@@ -403,9 +411,9 @@ def generate_candidates(
             )
             candidate_trackers.append(new_candidate)
         else:
-            candidate_trackers[
-                int(mlir.stem.split("_config")[0])
-            ].mlir_config_path = mlir
+            candidate_trackers[int(mlir.stem.split("_config")[0])].mlir_config_path = (
+                mlir
+            )
 
     handle_error(
         condition=(len(candidates) == 0), msg="Failed to generate any candidates"
@@ -467,7 +475,7 @@ def compile_candidates(
     handle_error(
         condition=(compiling_rate < 10),
         msg=f"Compiling rate [{compiling_rate:.1f}%] < 10%",
-        level=logging.WARNING
+        level=logging.WARNING,
     )
 
     return compiled_files, compiled_dir
@@ -529,7 +537,7 @@ def benchmark_top_candidates(
     benchmark_failed_files = sorted(
         benchmark_failed_dir.glob("*.vmfb"), key=numerical_sort_key
     )
-    
+
     benchmarking_rate = (len(benchmarked_files) / len(benchmark_results)) * 100
     logging.critical(
         f"Total: {len(benchmark_results)} | Benchmarked: {len(benchmarked_files)} | Failed: {len(benchmark_failed_files)} | Benchmarking Rate: {benchmarking_rate:.1f}%"

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -337,7 +337,11 @@ def find_collisions(
 
 
 def load_pickle(file_path: Path) -> list[any]:
-    handle_error(condition=(not file_path.exists()), msg=f"Configuration file not found", error_type=FileNotFoundError)
+    handle_error(
+        condition=(not file_path.exists()),
+        msg=f"Configuration file not found: {file_path}",
+        error_type=FileNotFoundError,
+    )
     with open(file_path, "rb") as file:
         loaded_array = pickle.load(file)
     return loaded_array

--- a/tuning/test_tune.py
+++ b/tuning/test_tune.py
@@ -12,6 +12,7 @@ def test_get_shaped_type_element_bitwidth():
     assert tune.ShapedType([2048, 512, 384], tune.ElementType.f8).bitwidth == 8
     assert tune.ShapedType([1, 1], tune.ElementType.f16).bitwidth == 16
 
+
 def test_get_shaped_type_to_str():
     assert str(tune.ShapedType([1024, 2048], tune.ElementType.i8)) == "1024x2048xi8"
     assert str(tune.ShapedType([1024], tune.ElementType.f32)) == "1024xf32"
@@ -93,6 +94,7 @@ def test_get_pipeline_config():
         tune.get_pipeline_config(config2)
         == ', prefetch_shared_memory, llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}'
     )
+
 
 def test_get_shapes_mmt():
     template = [

--- a/tuning/tune.py
+++ b/tuning/tune.py
@@ -937,7 +937,7 @@ def tune(
             template, lhs_dims, rhs_dims, config
         )
     else:
-        assert False
+        assert False, f"Unhandled dispatch kind: {walk_result.dispatch_kind}"
 
     problem_size = get_shapes_fn(mlir_template)
     tune_logger.debug(str(problem_size))


### PR DESCRIPTION
Refactor the input module parser to track the original shapes and element types. Simplify the configuration enumeration logic to use a single loop shared between all dispatch types.

This is to enable tuning for dispatches with new data types (int8, fp8) without duplicating the existing logic.

Also add a verbose flag to `tune.py`.