### PR TITLE
[tuner] Add device validation for user devices

### DIFF
--- a/tuning/benchmark_dispatch.sh
+++ b/tuning/benchmark_dispatch.sh
@@ -12,7 +12,7 @@ readonly NAME="$(basename "$INPUT" .mlir)"
 
 # printf "Benchmarking $(basename ${INPUT}) on ${DEVICE}\n"
 
-timeout 16s ./tools/iree-benchmark-module --device="hip://${DEVICE}" --module="${INPUT}" \
+timeout 16s ./tools/iree-benchmark-module --device="${DEVICE}" --module="${INPUT}" \
   --hip_use_streams=true --hip_allow_inline_execution=true \
   --batch_size=1000 --benchmark_repetitions=3 > "${DIR}/benchmark_log_${DEVICE}.out" 2>&1 || (mv "$INPUT" "${DIR}/benchmark_failed" && exit 0)
 

--- a/tuning/benchmark_unet_candidate.sh
+++ b/tuning/benchmark_unet_candidate.sh
@@ -9,7 +9,7 @@ shift 2
 echo "Benchmarking: ${INPUT} on device ${DEVICE}"
 
 timeout 180s tools/iree-benchmark-module \
-  --device="hip://${DEVICE}" \
+  --device="${DEVICE}" \
   --hip_use_streams=true \
   --hip_allow_inline_execution=true \
   --device_allocator=caching \

--- a/tuning/test_autotune.py
+++ b/tuning/test_autotune.py
@@ -1,4 +1,6 @@
+import argparse
 import pytest
+from unittest.mock import call, patch, MagicMock
 import autotune
 
 """
@@ -363,3 +365,112 @@ def test_parse_grouped_benchmark_results():
     assert (
         dump_list == expect_dump_list
     ), "fail to parse incomplete baseline and candidates"
+def test_extract_driver_names():
+    user_devices = ["hip://0", "local-sync://default", "cuda://default"]
+    expected_output = {"hip", "local-sync", "cuda"}
+
+    assert autotune.extract_driver_names(user_devices) == expected_output
+
+def test_fetch_available_devices_success():
+    drivers = ["hip", "local-sync", "cuda"]
+    mock_devices = {
+        "hip": [{"path": "0"}],
+        "local-sync": [{"path": "default"}],
+        "cuda": [{"path": "default"}]
+    }
+    
+    with patch("autotune.ireert.get_driver") as mock_get_driver:
+        mock_driver = MagicMock()
+        
+        def get_mock_driver(name):
+            mock_driver.query_available_devices.side_effect = lambda: mock_devices[name]
+            return mock_driver
+        
+        mock_get_driver.side_effect = get_mock_driver
+        
+        actual_output = autotune.fetch_available_devices(drivers)
+        expected_output = ["hip://0", "local-sync://default", "cuda://default"]
+        
+        assert actual_output == expected_output
+
+def test_fetch_available_devices_failure():
+    drivers = ["hip", "local-sync", "cuda"]
+    mock_devices = {
+        "hip": [{"path": "0"}],
+        "local-sync": ValueError("Failed to initialize"),
+        "cuda": [{"path": "default"}]
+    }
+    
+    with patch("autotune.ireert.get_driver") as mock_get_driver:
+        with patch("autotune.handle_error") as mock_handle_error:
+            mock_driver = MagicMock()
+            
+            def get_mock_driver(name):
+                if isinstance(mock_devices[name], list):
+                    mock_driver.query_available_devices.side_effect = lambda: mock_devices[name]
+                else:
+                    mock_driver.query_available_devices.side_effect = lambda: (_ for _ in ()).throw(mock_devices[name])
+                return mock_driver
+            
+            mock_get_driver.side_effect = get_mock_driver
+            
+            actual_output = autotune.fetch_available_devices(drivers)
+            expected_output = ["hip://0", "cuda://default"]
+            
+            assert actual_output == expected_output
+            mock_handle_error.assert_called_once_with(
+                condition=True,
+                msg="Could not initialize driver local-sync: Failed to initialize",
+                error_type=ValueError,
+                exit_program=True,
+            )
+
+def test_parse_devices():
+    user_devices_str = "hip://0, local-sync://default, cuda://default"
+    expected_output = ["hip://0", "local-sync://default", "cuda://default"]
+    
+    with patch("autotune.handle_error") as mock_handle_error:
+        actual_output = autotune.parse_devices(user_devices_str)
+        assert actual_output == expected_output
+        
+        mock_handle_error.assert_not_called()
+
+def test_parse_devices_with_invalid_input():
+    user_devices_str = "hip://0, local-sync://default, invalid_device, cuda://default"
+    expected_output = ["hip://0", "local-sync://default", "invalid_device", "cuda://default"]
+    
+    with patch("autotune.handle_error") as mock_handle_error:
+        actual_output = autotune.parse_devices(user_devices_str)
+        assert actual_output == expected_output
+        
+        mock_handle_error.assert_called_once_with(
+            condition=True,
+            msg=f"Invalid device list: {user_devices_str}. Error: {ValueError()}",
+            error_type=argparse.ArgumentTypeError,
+        )
+
+def test_validate_devices():
+    user_devices = ["hip://0", "local-sync://default"]
+    user_drivers = {"hip", "local-sync"}
+
+    with patch('autotune.extract_driver_names', return_value=user_drivers):
+        with patch('autotune.fetch_available_devices', return_value=["hip://0", "local-sync://default"]):
+            with patch('autotune.handle_error') as mock_handle_error:
+                autotune.validate_devices(user_devices)
+                assert all(call[1]['condition'] is False for call in mock_handle_error.call_args_list)
+
+def test_validate_devices_with_invalid_device():
+    user_devices = ["hip://0", "local-sync://default", "cuda://default"]
+    user_drivers = {"hip", "local-sync", "cuda"}
+
+    with patch("autotune.extract_driver_names", return_value=user_drivers):
+        with patch("autotune.fetch_available_devices", return_value=["hip://0", "local-sync://default"]):
+            with patch("autotune.handle_error") as mock_handle_error:
+                autotune.validate_devices(user_devices)
+                expected_call = call(
+                    condition=True,
+                    msg=f"Invalid device specified: cuda://default",
+                    error_type=argparse.ArgumentError,
+                    exit_program=True,
+                )
+                assert expected_call in mock_handle_error.call_args_list


### PR DESCRIPTION
The input will be verified against the available devices on the user's machine.

The old implementation of `--devices` was taking in an integer, it will now take in a string representing the device's Path / UUID.

* Adds: `fetch_available_devices() -> list[any]` - Returns the list of all of the devices found by the IREE Runtime module
* Adds: `validate_devices(user_devices) -> None` - Takes in the user input and checks it against the available devices and throws an error if at least one of the user's devices is invalid.
* Modified: `parse_devices(devices_str: str) -> list[str]` - The documentation of the method has been updated and `validate_devices` will be called to validate the user input
* Modified: `parse_arguments()` - The help message has been updated to better represent what the new input format for `--devices` is expected to look like
* Fixed typo: `Bnechmarking` -> `Benchmarking`