### PR TITLE
[tuner] Fix missing return bug and incorrect sort order in best.log

### DIFF
--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -262,6 +262,8 @@ def run_command(
     except KeyboardInterrupt:
         print("Ctrl+C detected, terminating child processes...")
 
+    return result
+
 
 def run_command_wrapper(
     task_tuple: tuple[argparse.Namespace, list[str], bool]
@@ -556,7 +558,7 @@ def benchmark_compiled_candidates(
         msg="Failed to benchmark all candidate .vmfb files",
     )
 
-    best_results = sorted(best_results, key=lambda x: x[0])[:20]
+    best_results = sorted(best_results, key=lambda x: float(x[0]))[:20]
     best_log = base_dir / "best.log"
     with best_log.open("w") as log_file:
         for result in best_results:


### PR DESCRIPTION
1. `run_command()` missing return `result` after merged #65 
2. Solved the legacy issue where the actual best candidates are not listed properly in `best.log` in `benchmark_compiled_candidates()`.

> print([i[0] for i in best_results])
> best_results = sorted(best_results, key=lambda x: x[0])
> print([i[0] for i in best_results])
> /*
> ['715.0', '921.0', '727.0', '728.0', '925.0', '727.0', '925.0', '735.0', '806.0', '1063.0', '1062.0', '1064.0', '1078.0', '798.0']
> ['1062.0', '1063.0', '1064.0', '1078.0', '715.0', '727.0', '727.0', '728.0', '735.0', '798.0', '806.0', '921.0', '925.0', '925.0']
> */
- `x[0]` is type `str`, and they are sorted lexicographically, which is why "1062.0" comes before "715.0".
- Convert to `float` will solve the issue

