### PR TITLE
[int8] Add --iree-opt-outer-dim-concat flag

### DIFF
--- a/int8-model/compile-punet-base.sh
+++ b/int8-model/compile-punet-base.sh
@@ -43,6 +43,7 @@ set -x
     --iree-rocm-target-chip="$CHIP" \
     --iree-rocm-bc-dir="${SCRIPT_DIR}/../bitcode-6.1.2" \
     --iree-opt-const-eval=false \
+    --iree-opt-outer-dim-concat=true \
     --iree-opt-data-tiling=false \
     --iree-global-opt-propagate-transposes=true \
     --iree-opt-aggressively-propagate-transposes=true \


### PR DESCRIPTION
There are several concat ops alog the innermost dimension, causing slow memcpys.

Stats:
- Total dispatches: -9
- Copies: +6
- Slow memcpys went from 42 -> 4