### PR TITLE
[tuner] Add dry run mode to enable testing without mi300

### DIFF
--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, field
 from typing import Type, Optional, Callable, Iterable, Any
 import pickle
 from itertools import groupby
+import random
 
 """
 Sample Usage:
@@ -194,7 +195,7 @@ class DispatchBenchmarkResult:
             return float(self.get_tokens()[3])
         except ValueError:
             return None
-        
+
     def generate_sample_result(
         self, candidate_id: int = 0, mean_time: int | float = random.randint(100, 500)
     ) -> str:
@@ -847,7 +848,9 @@ def benchmark_compiled_candidates(
     logging.info("benchmark_top_candidates()")
 
     if args.dry_run:
-        benchmark_results = generate_dryrun_dispatch_benchmark_results(compiled_candidates)
+        benchmark_results = generate_dryrun_dispatch_benchmark_results(
+            compiled_candidates
+        )
     else:
         # Benchmarking dispatch candidates
         task_list = []
@@ -1132,7 +1135,9 @@ def benchmark_unet(
             initializer_inputs=(worker_context_queue,),
         )
         benchmark_results = sorted(benchmark_results, key=lambda br: br.device_id)
-        grouped_benchmark_results = group_benchmark_results_by_device_id(benchmark_results)
+        grouped_benchmark_results = group_benchmark_results_by_device_id(
+            benchmark_results
+        )
 
         # Benchmarking baselines on each involved device
         worker_context_queue = create_worker_context_queue(args.devices)

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -1094,15 +1094,14 @@ def generate_dryrun_unet_benchmark_results(
 def dryrun_benchmark_unet(
     path_config: PathConfig,
     unet_candidates: list[int],
-    candidate_trackers: list[CandidateTracker],):
+    candidate_trackers: list[CandidateTracker],
+):
 
     unet_vmfb_paths = [path_config.unet_baseline_vmfb] + [
         candidate_trackers[i].unet_candidate_path for i in unet_candidates
     ]
     benchmark_results = generate_dryrun_unet_benchmark_results(unet_vmfb_paths)
-    grouped_benchmark_results = group_benchmark_results_by_device_id(
-        benchmark_results
-    )
+    grouped_benchmark_results = group_benchmark_results_by_device_id(benchmark_results)
 
     # Update candidate_tracker and extract strings which will be stored in unet_result_log
     dump_list = parse_grouped_benchmark_results(
@@ -1153,9 +1152,7 @@ def benchmark_unet(
         initializer_inputs=(worker_context_queue,),
     )
     benchmark_results = sorted(benchmark_results, key=lambda br: br.device_id)
-    grouped_benchmark_results = group_benchmark_results_by_device_id(
-        benchmark_results
-    )
+    grouped_benchmark_results = group_benchmark_results_by_device_id(benchmark_results)
 
     # Benchmarking baselines on each involved device
     worker_context_queue = create_worker_context_queue(args.devices)

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -269,7 +269,7 @@ class UnetBenchmarkResult:
         device_id: int = 0,
         t1: int | float = random.randint(100, 500),
     ) -> str:
-        return f"Benchmarking: {candidate_vmfb_path_str} on device {device_id}\nBM_run_forward/process_time/real_time_median\t    {t1:.3g} ms\t    {(t1+1):.3g} ms\t      5 items_per_second={t1/200:5f}/s\n"
+        return f"Benchmarking: {candidate_vmfb_path_str} on device {device_id}\nBM_run_forward/process_time/real_time_median\t    {t1:.3g} ms\t    {(t1+1):.3g} ms\t      5 items_per_second={t1/200:5f}/s\n\n"
 
 
 def parse_devices(devices_str: str) -> list[int]:
@@ -825,7 +825,6 @@ def generate_dryrun_dispatch_benchmark_results(
 ) -> list[TaskResult]:
     task_results = []
     for candidate_id in compiled_candidates:
-        # print(DispatchBenchmarkResult().generate_sample_result(candidate_id))
         task_result = subprocess.CompletedProcess(
             args=[""],
             returncode=0,
@@ -1084,7 +1083,7 @@ def generate_dryrun_unet_benchmark_results(
             ),
             stderr="",
         )
-        start += random.randint(-1, 10)
+        start += random.randint(-5, 8)
         task_results.append(TaskResult(task_result, device_id))
     return task_results
 

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -199,7 +199,8 @@ class DispatchBenchmarkResult:
     def generate_sample_result(
         self, candidate_id: int = 0, mean_time: float = random.uniform(100.0, 500.0)
     ) -> str:
-        return f"{candidate_id}\tMean Time: {mean_time:.1f}\n" # time in ms
+        # time unit is implicit and dependent on the output of iree-benchmark-module
+        return f"{candidate_id}\tMean Time: {mean_time:.1f}\n"
 
 
 @dataclass

--- a/tuning/test_autotune.py
+++ b/tuning/test_autotune.py
@@ -224,7 +224,7 @@ def test_parse_grouped_benchmark_results():
 def test_generate_sample_result():
     res = autotune.DispatchBenchmarkResult()
     output = res.generate_sample_result(1, 3.14)
-    expect = f"1\tMean Time: 3.1\n"
+    expected = f"1\tMean Time: 3.1\n"
     assert output == expect, "DispatchBenchmarkResult generates invalid sample string"
 
     res = autotune.UnetBenchmarkResult()

--- a/tuning/test_autotune.py
+++ b/tuning/test_autotune.py
@@ -216,3 +216,15 @@ def test_parse_grouped_benchmark_results():
     assert (
         candidate_trackers == expect_candidate_trackers
     ), "candidate_trackers did not change as expected"
+
+
+def test_generate_sample_result():
+    res = autotune.DispatchBenchmarkResult()
+    output = res.generate_sample_result(1, 3.14)
+    expect = f"1\tMean Time: 3.1\n"
+    assert (output == expect), "DispatchBenchmarkResult generates invalid sample string"
+
+    res = autotune.UnetBenchmarkResult()
+    output = res.generate_sample_result(1, "some_dir/tuning_2024_07_24_20_06/unet_candidate_60.vmfb.vmfb", 576.89)
+    expect = f"Benchmarking: 1 on device some_dir/tuning_2024_07_24_20_06/unet_candidate_60.vmfb.vmfb\nBM_run_forward/process_time/real_time_median\t    577 ms\t    578 ms\t      5 items_per_second=2.884450/s\n\n"
+    assert (output == expect), "UnetBenchmarkResult generates invalid sample string"

--- a/tuning/test_autotune.py
+++ b/tuning/test_autotune.py
@@ -225,11 +225,11 @@ def test_generate_sample_result():
     res = autotune.DispatchBenchmarkResult()
     output = res.generate_sample_result(1, 3.14)
     expected = f"1\tMean Time: 3.1\n"
-    assert output == expect, "DispatchBenchmarkResult generates invalid sample string"
+    assert output == expected, "DispatchBenchmarkResult generates invalid sample string"
 
     res = autotune.UnetBenchmarkResult()
     output = res.generate_sample_result(
         1, "some_dir/tuning_2024_07_24_20_06/unet_candidate_60.vmfb.vmfb", 576.89
     )
     expected = f"Benchmarking: 1 on device some_dir/tuning_2024_07_24_20_06/unet_candidate_60.vmfb.vmfb\nBM_run_forward/process_time/real_time_median\t    577 ms\t    578 ms\t      5 items_per_second=2.884450/s\n\n"
-    assert output == expect, "UnetBenchmarkResult generates invalid sample string"
+    assert output == expected, "UnetBenchmarkResult generates invalid sample string"

--- a/tuning/test_autotune.py
+++ b/tuning/test_autotune.py
@@ -231,5 +231,5 @@ def test_generate_sample_result():
     output = res.generate_sample_result(
         1, "some_dir/tuning_2024_07_24_20_06/unet_candidate_60.vmfb.vmfb", 576.89
     )
-    expect = f"Benchmarking: 1 on device some_dir/tuning_2024_07_24_20_06/unet_candidate_60.vmfb.vmfb\nBM_run_forward/process_time/real_time_median\t    577 ms\t    578 ms\t      5 items_per_second=2.884450/s\n\n"
+    expected = f"Benchmarking: 1 on device some_dir/tuning_2024_07_24_20_06/unet_candidate_60.vmfb.vmfb\nBM_run_forward/process_time/real_time_median\t    577 ms\t    578 ms\t      5 items_per_second=2.884450/s\n\n"
     assert output == expect, "UnetBenchmarkResult generates invalid sample string"

--- a/tuning/test_autotune.py
+++ b/tuning/test_autotune.py
@@ -58,7 +58,10 @@ def test_find_collisions():
     input = [(1, "abc"), (2, "def"), (3, "abc")]
     assert autotune.find_collisions(input) == (True, [("abc", [1, 3]), ("def", [2])])
     input = [(1, "abc"), (2, "def"), (3, "hig")]
-    assert autotune.find_collisions(input) == (False, [("abc", [1]), ("def", [2]), ("hig", [3])])
+    assert autotune.find_collisions(input) == (
+        False,
+        [("abc", [1]), ("def", [2]), ("hig", [3])],
+    )
 
 
 def test_collision_handler():
@@ -222,9 +225,11 @@ def test_generate_sample_result():
     res = autotune.DispatchBenchmarkResult()
     output = res.generate_sample_result(1, 3.14)
     expect = f"1\tMean Time: 3.1\n"
-    assert (output == expect), "DispatchBenchmarkResult generates invalid sample string"
+    assert output == expect, "DispatchBenchmarkResult generates invalid sample string"
 
     res = autotune.UnetBenchmarkResult()
-    output = res.generate_sample_result(1, "some_dir/tuning_2024_07_24_20_06/unet_candidate_60.vmfb.vmfb", 576.89)
+    output = res.generate_sample_result(
+        1, "some_dir/tuning_2024_07_24_20_06/unet_candidate_60.vmfb.vmfb", 576.89
+    )
     expect = f"Benchmarking: 1 on device some_dir/tuning_2024_07_24_20_06/unet_candidate_60.vmfb.vmfb\nBM_run_forward/process_time/real_time_median\t    577 ms\t    578 ms\t      5 items_per_second=2.884450/s\n\n"
-    assert (output == expect), "UnetBenchmarkResult generates invalid sample string"
+    assert output == expect, "UnetBenchmarkResult generates invalid sample string"


### PR DESCRIPTION
- Added --dry-run option to allow user running autotune.py without mi300
- Add `generate_dryrun_dispatch_benchmark_results()` and `generate_dryrun_unet_benchmark_results()`
> `benchmark_compiled_candidates()` and `benchmark_unet()` will generate fake results when in dry-run mode

