### PR TITLE
[tuner] Add pytest for autotune.py

### DIFF
--- a/tuning/test_autotune.py
+++ b/tuning/test_autotune.py
@@ -1,0 +1,85 @@
+import pytest
+import autotune
+
+"""
+Usage: python -m pytest test_autotune.py
+"""
+
+
+def test_group_benmark_results_by_device_id():
+    def generate_res(res_arg: str, device_id: int) -> autotune.TaskResult:
+        result = autotune.subprocess.CompletedProcess(
+            args=[res_arg],
+            returncode=0,
+        )
+        return autotune.TaskResult(result=result, device_id=device_id)
+
+    test_input = [
+        generate_res("str1", 3),
+        generate_res("str7", 4),
+        generate_res("str2", 1),
+        generate_res("str5", 3),
+        generate_res("str5", 7),
+        generate_res("str3", 4),
+    ]
+    expect_output = [
+        [generate_res("str2", 1)],
+        [generate_res("str1", 3), generate_res("str5", 3)],
+        [generate_res("str7", 4), generate_res("str3", 4)],
+        [generate_res("str5", 7)],
+    ]
+
+    actual_output = autotune.group_benchmark_results_by_device_id(test_input)
+
+    for a, e in zip(actual_output, expect_output):
+        for res1, res2 in zip(a, e):
+            assert res1.result.args == res2.result.args
+            assert res1.device_id == res2.device_id
+
+
+def test_sort_candidates_by_first_benchmark_times():
+    candidate_trackers = [autotune.CandidateTracker(i) for i in range(5)]
+    candidate_trackers[0].first_benchmark_time = 35
+    candidate_trackers[1].first_benchmark_time = 2141
+    candidate_trackers[2].first_benchmark_time = 231
+    candidate_trackers[3].first_benchmark_time = 231.23
+    candidate_trackers[4].first_benchmark_time = 58
+    test_input = [i for i in range(5)]
+    expect_output = [0, 4, 2, 3, 1]
+    assert (
+        autotune.sort_candidates_by_first_benchmark_times(
+            test_input, candidate_trackers
+        )
+        == expect_output
+    )
+
+
+def test_find_collisions():
+    input = [(1, "abc"), (2, "def"), (3, "abc")]
+    assert autotune.find_collisions(input) == (True, [("abc", [1, 3]), ("def", [2])])
+
+
+def test_UnetBenchmarkResult_calibrated_output_str():
+    baseline_time = 423
+    res_time = 304
+    result_str = f"Benchmarking: tuning_2024_07_22_16_29/unet_candidate_16.vmfb on device 0\nBM_run_forward/process_time/real_time_median	    {res_time} ms	    305 ms	      5 items_per_second=1.520000/s"
+    change = (res_time - baseline_time) / baseline_time
+    output_str = autotune.UnetBenchmarkResult(result_str).calibrated_output_str(change)
+    expect_str = f"Benchmarking: tuning_2024_07_22_16_29/unet_candidate_16.vmfb on device 0\nBM_run_forward/process_time/real_time_median            {res_time} ms (-28.132%)         305 ms            5 items_per_second=1.520000/s"
+    assert output_str == expect_str
+
+    baseline_time = 218
+    res_time = 218
+    result_str = f"Benchmarking: tuning_2024_07_22_16_29/unet_candidate_16.vmfb on device 0\nBM_run_forward/process_time/real_time_median	    {res_time} ms	    305 ms	      5 items_per_second=1.520000/s"
+    change = (res_time - baseline_time) / baseline_time
+    output_str = autotune.UnetBenchmarkResult(result_str).calibrated_output_str(change)
+    expect_str = f"Benchmarking: tuning_2024_07_22_16_29/unet_candidate_16.vmfb on device 0\nBM_run_forward/process_time/real_time_median            {res_time} ms (+0.000%)         305 ms            5 items_per_second=1.520000/s"
+    assert output_str == expect_str
+
+    baseline_time = 123
+    res_time = 345
+    result_str = f"Benchmarking: tuning_2024_07_22_16_29/unet_candidate_16.vmfb on device 0\nBM_run_forward/process_time/real_time_median	    {res_time} ms	    305 ms	      5 items_per_second=1.520000/s"
+    change = (res_time - baseline_time) / baseline_time
+    output_str = autotune.UnetBenchmarkResult(result_str).calibrated_output_str(change)
+    expect_str = f"Benchmarking: tuning_2024_07_22_16_29/unet_candidate_16.vmfb on device 0\nBM_run_forward/process_time/real_time_median            {res_time} ms (+180.488%)         305 ms            5 items_per_second=1.520000/s"
+    assert output_str == expect_str


### PR DESCRIPTION
Matches to autotune version in #76 
- `test_group_benmark_results_by_device_id()`
- `test_sort_candidates_by_first_benchmark_times()`
- `test_find_collisions()`
- 'test_UnetBenchmarkResult_calibrated_output_str()`