### PR TITLE
[tuner] Handle incomplete benchmark results

### DIFF
--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -269,7 +269,7 @@ class UnetBenchmarkResult:
         self,
         candidate_vmfb_path_str: str = "unet_baseline.vmfb",
         device_id: int = 0,
-        t1: float = random.uniform(100.0, 500.0), # time in ms
+        t1: float = random.uniform(100.0, 500.0),  # time in ms
     ) -> str:
         return f"Benchmarking: {candidate_vmfb_path_str} on device {device_id}\nBM_run_forward/process_time/real_time_median\t    {t1:.3g} ms\t    {(t1+1):.3g} ms\t      5 items_per_second={t1/200:5f}/s\n\n"
 
@@ -1038,7 +1038,9 @@ def parse_grouped_benchmark_results(
 ) -> Optional[list[str]]:
     """Update candidate_trackers and collect strings"""
     dump_list = []
-    incomplete_list: [tuple[int, int]] = [] # format: [(candidate_id, device_id)], baseline will have candidate_id=0
+    incomplete_list: [
+        tuple[int, int]
+    ] = []  # format: [(candidate_id, device_id)], baseline will have candidate_id=0
 
     for same_device_results in grouped_benchmark_results:
         dump_unsort_list: list[tuple[int, str]] = []
@@ -1046,7 +1048,7 @@ def parse_grouped_benchmark_results(
             # skip if benchmark failed
             if not unet_candidate_result.result.stdout:
                 continue
-    
+
             res = UnetBenchmarkResult(unet_candidate_result.result.stdout)
 
             # record baseline benchmarking result
@@ -1058,7 +1060,7 @@ def parse_grouped_benchmark_results(
                 dump_list.append(res.result_str)
                 continue
 
-            # record candidate benchmarking result 
+            # record candidate benchmarking result
             c_id = res.get_candidate_id()
             candidate_time = res.get_benchmark_time()
             if not candidate_time:
@@ -1072,18 +1074,26 @@ def parse_grouped_benchmark_results(
                 continue
             # calculate candidate improvement based baseline
             candidate_trackers[c_id].baseline_benchmark_time = baseline_time
-            candidate_trackers[c_id].calibrated_benchmark_diff = (candidate_time - baseline_time) / baseline_time
+            candidate_trackers[c_id].calibrated_benchmark_diff = (
+                candidate_time - baseline_time
+            ) / baseline_time
             dump_str = res.get_calibrated_result_str(
                 candidate_trackers[c_id].calibrated_benchmark_diff
             )
             dump_unsort_list.append([candidate_time, dump_str])
-        
+
         # sort unet candidate benchmarking result str in ascending time order
-        dump_list = dump_list + [dump_str for _, dump_str in sorted(dump_unsort_list, key=lambda x: x[0])]
+        dump_list = dump_list + [
+            dump_str for _, dump_str in sorted(dump_unsort_list, key=lambda x: x[0])
+        ]
 
     # store incomplete .vmfb file at the end of dump_list
     for index, device_id in incomplete_list:
-        index_to_path = lambda index: f"{path_config.unet_baseline_vmfb.as_posix()}" if index == 0 else f"{candidate_trackers[index].unet_candidate_path}"
+        index_to_path = (
+            lambda index: f"{path_config.unet_baseline_vmfb.as_posix()}"
+            if index == 0
+            else f"{candidate_trackers[index].unet_candidate_path}"
+        )
         error_msg = f"Benchmarking result of {index_to_path(index)} on deivce {device_id} is incomplete"
         handle_error(condition=True, msg=error_msg, level=logging.WARNING)
         dump_list.append(error_msg + "\n")

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -1068,7 +1068,7 @@ def parse_grouped_benchmark_results(
                 continue
             candidate_trackers[c_id].unet_benchmark_time = candidate_time
             candidate_trackers[c_id].unet_benchmark_device_id = res.get_device_id()
-            # skip improvement calculation if no baseline data
+            # Skip improvement calculation if no baseline data.
             if not baseline_time:
                 dump_unsort_list.append([candidate_time, res.result_str])
                 continue

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -1087,7 +1087,7 @@ def parse_grouped_benchmark_results(
             dump_str for _, dump_str in sorted(dump_unsort_list, key=lambda x: x[0])
         ]
 
-    # store incomplete .vmfb file at the end of dump_list
+    # Store incomplete .vmfb file at the end of dump_list.
     for index, device_id in incomplete_list:
         index_to_path = (
             lambda index: f"{path_config.unet_baseline_vmfb.as_posix()}"

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -1072,7 +1072,7 @@ def parse_grouped_benchmark_results(
             if not baseline_time:
                 dump_unsort_list.append([candidate_time, res.result_str])
                 continue
-            # calculate candidate improvement based baseline
+            # Calculate candidate improvement based baseline.
             candidate_trackers[c_id].baseline_benchmark_time = baseline_time
             candidate_trackers[c_id].calibrated_benchmark_diff = (
                 candidate_time - baseline_time

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -1045,7 +1045,7 @@ def parse_grouped_benchmark_results(
     for same_device_results in grouped_benchmark_results:
         dump_unsort_list: list[tuple[int, str]] = []
         for unet_candidate_result in same_device_results:
-            # skip if benchmark failed
+            # Skip if benchmark failed.
             if not unet_candidate_result.result.stdout:
                 continue
 

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -1082,7 +1082,7 @@ def parse_grouped_benchmark_results(
             )
             dump_unsort_list.append([candidate_time, dump_str])
 
-        # sort unet candidate benchmarking result str in ascending time order
+        # Sort unet candidate benchmarking result str in ascending time order.
         dump_list = dump_list + [
             dump_str for _, dump_str in sorted(dump_unsort_list, key=lambda x: x[0])
         ]

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -1051,7 +1051,7 @@ def parse_grouped_benchmark_results(
 
             res = UnetBenchmarkResult(unet_candidate_result.result.stdout)
 
-            # record baseline benchmarking result
+            # Record baseline benchmarking result.
             if str(path_config.unet_baseline_vmfb) in res.get_unet_candidate_path():
                 baseline_time = res.get_benchmark_time()
                 if not baseline_time:

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -1060,7 +1060,7 @@ def parse_grouped_benchmark_results(
                 dump_list.append(res.result_str)
                 continue
 
-            # record candidate benchmarking result
+            # Record candidate benchmarking result.
             c_id = res.get_candidate_id()
             candidate_time = res.get_benchmark_time()
             if not candidate_time:

--- a/tuning/test_autotune.py
+++ b/tuning/test_autotune.py
@@ -186,7 +186,12 @@ def test_parse_grouped_benchmark_results():
 
     grouped_benchmark_results = [
         [generate_res(b1, 0), generate_res(s1, 0)],
-        [generate_res(b2, 1), generate_res("", 1), generate_res(s2, 1), generate_res(s3, 1)],
+        [
+            generate_res(b2, 1),
+            generate_res("", 1),
+            generate_res(s2, 1),
+            generate_res(s3, 1),
+        ],
     ]
 
     path_config = autotune.PathConfig()
@@ -216,7 +221,7 @@ def test_parse_grouped_benchmark_results():
         path_config, grouped_benchmark_results, candidate_trackers
     )
 
-    assert (dump_list == expect_dump_list), "basic parsing is incorrect"
+    assert dump_list == expect_dump_list, "basic parsing is incorrect"
     assert (
         candidate_trackers != candidate_trackers_before
     ), "candidate_trackers should be modified"
@@ -224,7 +229,6 @@ def test_parse_grouped_benchmark_results():
         candidate_trackers == expect_candidate_trackers
     ), "candidate_trackers did not change as expected"
 
-    
     b1 = "Benchmarking: unet_baseline.vmfb on device 0"
     s1 = "Benchmarking: unet_candidate_1.vmfb on device 0 BM_main/process_time/real_time_median 62.4 ms 15.4 ms 5 items_per_second=16.0223/s"
     grouped_benchmark_results = [[generate_res(b1, 0), generate_res(s1, 0)]]
@@ -234,10 +238,9 @@ def test_parse_grouped_benchmark_results():
     expect_dump_list = [
         "Benchmarking: unet_candidate_1.vmfb on device 0 "
         "BM_main/process_time/real_time_median 62.4 ms 15.4 ms 5 items_per_second=16.0223/s",
-        "Benchmarking result of unet_baseline.vmfb on deivce 0 is incomplete\n"
+        "Benchmarking result of unet_baseline.vmfb on deivce 0 is incomplete\n",
     ]
-    assert (dump_list == expect_dump_list), "fail to parse incomplete baselines" 
-
+    assert dump_list == expect_dump_list, "fail to parse incomplete baselines"
 
     b1 = "Benchmarking: some_dir/unet_baseline.vmfb on device 0 BM_main/process_time/real_time_median 60.7 ms 13.5 ms 5 items_per_second=16.4733/s"
     s1 = "Benchmarking: unet_candidate_1.vmfb on device 0"
@@ -249,10 +252,9 @@ def test_parse_grouped_benchmark_results():
     expect_dump_list = [
         "Benchmarking: some_dir/unet_baseline.vmfb on device 0 "
         "BM_main/process_time/real_time_median 60.7 ms 13.5 ms 5 items_per_second=16.4733/s",
-        "Benchmarking result of unet_candidate_1.vmfb on deivce 0 is incomplete\n"
+        "Benchmarking result of unet_candidate_1.vmfb on deivce 0 is incomplete\n",
     ]
-    assert (dump_list == expect_dump_list), "fail to parse incomplete candidates"
-
+    assert dump_list == expect_dump_list, "fail to parse incomplete candidates"
 
     b1 = "Benchmarking: unet_baseline.vmfb on device 0"
     s1 = "Benchmarking: unet_candidate_1.vmfb on device 0"
@@ -263,9 +265,11 @@ def test_parse_grouped_benchmark_results():
     )
     expect_dump_list = [
         "Benchmarking result of unet_baseline.vmfb on deivce 0 is incomplete\n",
-        "Benchmarking result of unet_candidate_1.vmfb on deivce 0 is incomplete\n"
+        "Benchmarking result of unet_candidate_1.vmfb on deivce 0 is incomplete\n",
     ]
-    assert (dump_list == expect_dump_list), "fail to parse incomplete baseline and candidates"
+    assert (
+        dump_list == expect_dump_list
+    ), "fail to parse incomplete baseline and candidates"
 
 
 def test_generate_sample_result():

--- a/tuning/test_autotune.py
+++ b/tuning/test_autotune.py
@@ -181,11 +181,12 @@ def test_parse_grouped_benchmark_results():
     b1 = "Benchmarking: some_dir/unet_baseline.vmfb on device 0 BM_main/process_time/real_time_median 60.7 ms 13.5 ms 5 items_per_second=16.4733/s"
     b2 = "Benchmarking: unet_baseline.vmfb on device 1 BM_main/process_time/real_time_median 59.8 ms 15.1 ms 5 items_per_second=16.7114/s"
     s1 = "Benchmarking: unet_candidate_1.vmfb on device 0 BM_main/process_time/real_time_median 62.4 ms 15.4 ms 5 items_per_second=16.0223/s"
-    s2 = "Benchmarking: some_dir/unet_candidate_4.vmfb on device 1 BM_main/process_time/real_time_median 61.4 ms 11.0 ms 5 items_per_second=16.2958/s"
+    s2 = "Benchmarking: some_dir/unet_candidate_2.vmfb on device 1 BM_main/process_time/real_time_median 61.4 ms 11.0 ms 5 items_per_second=16.2958/s"
+    s3 = "Benchmarking: unet_candidate_4.vmfb on device 1 BM_main/process_time/real_time_median 57.4 ms 11.0 ms 5 items_per_second=16.2958/s"
 
     grouped_benchmark_results = [
         [generate_res(b1, 0), generate_res(s1, 0)],
-        [generate_res(b2, 1), generate_res("", 1), generate_res(s2, 1)],
+        [generate_res(b2, 1), generate_res("", 1), generate_res(s2, 1), generate_res(s3, 1)],
     ]
 
     path_config = autotune.PathConfig()
@@ -195,7 +196,8 @@ def test_parse_grouped_benchmark_results():
     candidate_trackers_before = [autotune.CandidateTracker(i) for i in range(5)]
     expect_candidate_trackers = [autotune.CandidateTracker(i) for i in range(5)]
     set_tracker(expect_candidate_trackers[1], 62.4, 0, 60.7, 0.028006589785831888)
-    set_tracker(expect_candidate_trackers[4], 61.4, 1, 59.8, 0.02675585284280939)
+    set_tracker(expect_candidate_trackers[2], 61.4, 1, 59.8, 0.02675585284280939)
+    set_tracker(expect_candidate_trackers[4], 57.4, 1, 59.8, -0.04013377926421403)
 
     expect_dump_list = [
         "Benchmarking: some_dir/unet_baseline.vmfb on device 0 "
@@ -204,7 +206,9 @@ def test_parse_grouped_benchmark_results():
         "BM_main/process_time/real_time_median 62.4 ms (+2.801%) 15.4 ms 5 items_per_second=16.0223/s",
         "Benchmarking: unet_baseline.vmfb on device 1 "
         "BM_main/process_time/real_time_median 59.8 ms 15.1 ms 5 items_per_second=16.7114/s",
-        "Benchmarking: some_dir/unet_candidate_4.vmfb on device 1 "
+        "Benchmarking: unet_candidate_4.vmfb on device 1 "
+        "BM_main/process_time/real_time_median 57.4 ms (-4.013%) 11.0 ms 5 items_per_second=16.2958/s",
+        "Benchmarking: some_dir/unet_candidate_2.vmfb on device 1 "
         "BM_main/process_time/real_time_median 61.4 ms (+2.676%) 11.0 ms 5 items_per_second=16.2958/s",
     ]
 
@@ -212,13 +216,56 @@ def test_parse_grouped_benchmark_results():
         path_config, grouped_benchmark_results, candidate_trackers
     )
 
-    assert dump_list == expect_dump_list
+    assert (dump_list == expect_dump_list), "basic parsing is incorrect"
     assert (
         candidate_trackers != candidate_trackers_before
     ), "candidate_trackers should be modified"
     assert (
         candidate_trackers == expect_candidate_trackers
     ), "candidate_trackers did not change as expected"
+
+    
+    b1 = "Benchmarking: unet_baseline.vmfb on device 0"
+    s1 = "Benchmarking: unet_candidate_1.vmfb on device 0 BM_main/process_time/real_time_median 62.4 ms 15.4 ms 5 items_per_second=16.0223/s"
+    grouped_benchmark_results = [[generate_res(b1, 0), generate_res(s1, 0)]]
+    dump_list = autotune.parse_grouped_benchmark_results(
+        path_config, grouped_benchmark_results, candidate_trackers
+    )
+    expect_dump_list = [
+        "Benchmarking: unet_candidate_1.vmfb on device 0 "
+        "BM_main/process_time/real_time_median 62.4 ms 15.4 ms 5 items_per_second=16.0223/s",
+        "Benchmarking result of unet_baseline.vmfb on deivce 0 is incomplete\n"
+    ]
+    assert (dump_list == expect_dump_list), "fail to parse incomplete baselines" 
+
+
+    b1 = "Benchmarking: some_dir/unet_baseline.vmfb on device 0 BM_main/process_time/real_time_median 60.7 ms 13.5 ms 5 items_per_second=16.4733/s"
+    s1 = "Benchmarking: unet_candidate_1.vmfb on device 0"
+    grouped_benchmark_results = [[generate_res(b1, 0), generate_res(s1, 0)]]
+    candidate_trackers[1].unet_candidate_path = "unet_candidate_1.vmfb"
+    dump_list = autotune.parse_grouped_benchmark_results(
+        path_config, grouped_benchmark_results, candidate_trackers
+    )
+    expect_dump_list = [
+        "Benchmarking: some_dir/unet_baseline.vmfb on device 0 "
+        "BM_main/process_time/real_time_median 60.7 ms 13.5 ms 5 items_per_second=16.4733/s",
+        "Benchmarking result of unet_candidate_1.vmfb on deivce 0 is incomplete\n"
+    ]
+    assert (dump_list == expect_dump_list), "fail to parse incomplete candidates"
+
+
+    b1 = "Benchmarking: unet_baseline.vmfb on device 0"
+    s1 = "Benchmarking: unet_candidate_1.vmfb on device 0"
+    grouped_benchmark_results = [[generate_res(b1, 0), generate_res(s1, 0)]]
+    candidate_trackers[1].unet_candidate_path = "unet_candidate_1.vmfb"
+    dump_list = autotune.parse_grouped_benchmark_results(
+        path_config, grouped_benchmark_results, candidate_trackers
+    )
+    expect_dump_list = [
+        "Benchmarking result of unet_baseline.vmfb on deivce 0 is incomplete\n",
+        "Benchmarking result of unet_candidate_1.vmfb on deivce 0 is incomplete\n"
+    ]
+    assert (dump_list == expect_dump_list), "fail to parse incomplete baseline and candidates"
 
 
 def test_generate_sample_result():


### PR DESCRIPTION
- if candidate or the baseline doesn't finish, it prints warning to the terminal and store in `unet_result.log`
- candidate unet results will be sorted in ascending benchmark time order
- add new test cases for `parse_grouped_benchmark_results()`