### PR TITLE
[tuner] Fix mypy errors. Add new test

### DIFF
--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -12,7 +12,7 @@ import time
 import multiprocessing
 import queue
 import tune
-from tqdm import tqdm # type: ignore
+from tqdm import tqdm  # type: ignore
 import re
 import hashlib
 from dataclasses import dataclass, field
@@ -719,7 +719,7 @@ def collision_handler(index_hash_list: list[tuple[int, str]]) -> tuple[bool, lis
     """If a collision is found, generate a list of new indexes. If no collision, `unique_indexes = []`"""
     # Check if candidate produces tbe same .vmfb
     collision_detected, hash_list = find_collisions(index_hash_list)
-    unique_indexes:list[int] = []
+    unique_indexes: list[int] = []
     if not collision_detected:
         return collision_detected, unique_indexes
 
@@ -991,7 +991,7 @@ def sort_candidates_by_first_benchmark_times(
     """Sorts candidate indexes based on their first benchmark times in ascending order"""
     # Get the first benchmark times, defaulting to a large number if None
     first_benchmark_times = [
-        candidate_trackers[index].first_benchmark_time or float('inf') 
+        candidate_trackers[index].first_benchmark_time or float("inf")
         for index in candidate_indexes
     ]
     combined = list(zip(candidate_indexes, first_benchmark_times))
@@ -1033,7 +1033,9 @@ def parse_grouped_benchmark_results(
 ) -> list[str]:
     """Update candidate_trackers and collect strings"""
     dump_list = []
-    incomplete_list: list[tuple[int, Optional[int]]] = []  # format: [(candidate_id, device_id)], baseline will have candidate_id=0
+    incomplete_list: list[
+        tuple[int, Optional[int]]
+    ] = []  # format: [(candidate_id, device_id)], baseline will have candidate_id=0
 
     for same_device_results in grouped_benchmark_results:
         dump_unsort_list: list[tuple[float, str]] = []
@@ -1048,7 +1050,10 @@ def parse_grouped_benchmark_results(
 
             # Record baseline benchmarking result.
             unet_candidate_path = res.get_unet_candidate_path()
-            if unet_candidate_path is not None and str(path_config.unet_baseline_vmfb) in unet_candidate_path:
+            if (
+                unet_candidate_path is not None
+                and str(path_config.unet_baseline_vmfb) in unet_candidate_path
+            ):
                 baseline_time = res.get_benchmark_time()
                 if baseline_time is None:
                     incomplete_list.append((0, device_id))
@@ -1072,7 +1077,9 @@ def parse_grouped_benchmark_results(
             # Calculate candidate improvement based baseline.
             candidate_trackers[c_id].baseline_benchmark_time = baseline_time
             calibrated_benchmark_diff = (candidate_time - baseline_time) / baseline_time
-            candidate_trackers[c_id].calibrated_benchmark_diff = calibrated_benchmark_diff
+            candidate_trackers[
+                c_id
+            ].calibrated_benchmark_diff = calibrated_benchmark_diff
             dump_str = res.get_calibrated_result_str(calibrated_benchmark_diff)
             assert dump_str is not None
             dump_unsort_list.append((candidate_time, dump_str))

--- a/tuning/test_autotune.py
+++ b/tuning/test_autotune.py
@@ -71,6 +71,86 @@ def test_collision_handler():
     assert autotune.collision_handler(input) == (False, [])
 
 
+def test_DispatchBenchmarkResult_get():
+    normal_str = "2	Mean Time: 586.0"
+    res = autotune.DispatchBenchmarkResult(normal_str)
+    assert res.result_str == normal_str
+    assert res.get_tokens() == ['2', 'Mean', 'Time:', '586.0']
+    assert res.get_candidate_id() == 2
+    assert res.get_benchmark_time() == 586.0
+    # normal_str = '4\tMean Time: 479.0'
+    # res = autotune.DispatchBenchmarkResult(normal_str)
+    # assert res.result_str == normal_str
+    # assert res.get_tokens() == ['4', 'Mean', 'Time:', '479.0']
+    # assert res.get_candidate_id() == 4
+    # assert res.get_benchmark_time() == 479.0
+
+    incomplete_str = "2	Mean Time:"
+    res = autotune.DispatchBenchmarkResult(incomplete_str)
+    assert res.get_tokens() == ['2', 'Mean', 'Time:']
+    assert res.get_candidate_id() == 2
+    assert res.get_benchmark_time() == None
+    incomplete_str = ""
+    res = autotune.DispatchBenchmarkResult(incomplete_str)
+    assert res.get_tokens() == []
+    assert res.get_candidate_id() == None
+    assert res.get_benchmark_time() == None
+
+    bad_str = 12345
+    res = autotune.DispatchBenchmarkResult(bad_str)
+    assert res.get_tokens() == []
+    assert res.get_candidate_id() == None
+    assert res.get_benchmark_time() == None
+
+
+def test_UnetBenchmarkResult_get():
+    normal_str = "Benchmarking: unet_candidate_12.vmfb on device 24\nBM_main/process_time/real_time_median 182 ms 183 ms 5 items_per_second=5.50302/s"
+    res = autotune.UnetBenchmarkResult(normal_str)
+    assert res.result_str == normal_str
+    assert res.get_tokens() == ['Benchmarking:', 'unet_candidate_12.vmfb', 'on', 'device', '24', 'BM_main/process_time/real_time_median', '182', 'ms', '183', 'ms', '5', 'items_per_second=5.50302/s']
+    assert res.get_unet_candidate_path() == 'unet_candidate_12.vmfb'
+    assert res.get_candidate_id() == 12
+    assert res.get_device_id() == 24
+    assert res.get_benchmark_time() == 182.0
+
+    incomplete_str = "Benchmarking: unet_baseline.vmfb on device 24\n"
+    res = autotune.UnetBenchmarkResult(incomplete_str)
+    assert res.get_tokens() == ['Benchmarking:', 'unet_baseline.vmfb', 'on', 'device', '24']
+    assert res.get_unet_candidate_path() == 'unet_baseline.vmfb'
+    assert res.get_candidate_id() == None
+    assert res.get_device_id() == 24
+    assert res.get_benchmark_time() == None
+    incomplete_str = ""
+    res = autotune.UnetBenchmarkResult(incomplete_str)
+    assert res.get_tokens() == []
+    assert res.get_unet_candidate_path() == None
+    assert res.get_candidate_id() == None
+    assert res.get_device_id() == None
+    assert res.get_benchmark_time() == None
+
+    bad_str = 12345
+    res = autotune.UnetBenchmarkResult(bad_str)
+    assert res.get_tokens() == []
+    assert res.get_unet_candidate_path() == None
+    assert res.get_candidate_id() == None
+    assert res.get_device_id() == None
+    assert res.get_benchmark_time() == None
+
+
+def test_generate_sample_result():
+    res = autotune.DispatchBenchmarkResult()
+    output = res.generate_sample_result(1, 3.14)
+    expected = f"1\tMean Time: 3.1\n"
+    assert output == expected, "DispatchBenchmarkResult generates invalid sample string"
+
+    res = autotune.UnetBenchmarkResult()
+    output = res.generate_sample_result(
+        1, "some_dir/tuning_2024_07_24_20_06/unet_candidate_60.vmfb.vmfb", 576.89
+    )
+    expected = f"Benchmarking: 1 on device some_dir/tuning_2024_07_24_20_06/unet_candidate_60.vmfb.vmfb\nBM_run_forward/process_time/real_time_median\t    577 ms\t    578 ms\t      5 items_per_second=2.884450/s\n\n"
+    assert output == expected, "UnetBenchmarkResult generates invalid sample string"
+
+
 def test_UnetBenchmarkResult_get_calibrated_result_str():
     baseline_time = 423
     res_time = 304
@@ -188,7 +268,7 @@ def test_parse_grouped_benchmark_results():
         [generate_res(b1, 0), generate_res(s1, 0)],
         [
             generate_res(b2, 1),
-            generate_res("", 1),
+            generate_res(None, 1),
             generate_res(s2, 1),
             generate_res(s3, 1),
         ],

--- a/tuning/test_autotune.py
+++ b/tuning/test_autotune.py
@@ -78,12 +78,6 @@ def test_DispatchBenchmarkResult_get():
     assert res.get_tokens() == ['2', 'Mean', 'Time:', '586.0']
     assert res.get_candidate_id() == 2
     assert res.get_benchmark_time() == 586.0
-    # normal_str = '4\tMean Time: 479.0'
-    # res = autotune.DispatchBenchmarkResult(normal_str)
-    # assert res.result_str == normal_str
-    # assert res.get_tokens() == ['4', 'Mean', 'Time:', '479.0']
-    # assert res.get_candidate_id() == 4
-    # assert res.get_benchmark_time() == 479.0
 
     incomplete_str = "2	Mean Time:"
     res = autotune.DispatchBenchmarkResult(incomplete_str)

--- a/tuning/test_autotune.py
+++ b/tuning/test_autotune.py
@@ -75,13 +75,13 @@ def test_DispatchBenchmarkResult_get():
     normal_str = "2	Mean Time: 586.0"
     res = autotune.DispatchBenchmarkResult(normal_str)
     assert res.result_str == normal_str
-    assert res.get_tokens() == ['2', 'Mean', 'Time:', '586.0']
+    assert res.get_tokens() == ["2", "Mean", "Time:", "586.0"]
     assert res.get_candidate_id() == 2
     assert res.get_benchmark_time() == 586.0
 
     incomplete_str = "2	Mean Time:"
     res = autotune.DispatchBenchmarkResult(incomplete_str)
-    assert res.get_tokens() == ['2', 'Mean', 'Time:']
+    assert res.get_tokens() == ["2", "Mean", "Time:"]
     assert res.get_candidate_id() == 2
     assert res.get_benchmark_time() == None
     incomplete_str = ""
@@ -101,16 +101,35 @@ def test_UnetBenchmarkResult_get():
     normal_str = "Benchmarking: unet_candidate_12.vmfb on device 24\nBM_main/process_time/real_time_median 182 ms 183 ms 5 items_per_second=5.50302/s"
     res = autotune.UnetBenchmarkResult(normal_str)
     assert res.result_str == normal_str
-    assert res.get_tokens() == ['Benchmarking:', 'unet_candidate_12.vmfb', 'on', 'device', '24', 'BM_main/process_time/real_time_median', '182', 'ms', '183', 'ms', '5', 'items_per_second=5.50302/s']
-    assert res.get_unet_candidate_path() == 'unet_candidate_12.vmfb'
+    assert res.get_tokens() == [
+        "Benchmarking:",
+        "unet_candidate_12.vmfb",
+        "on",
+        "device",
+        "24",
+        "BM_main/process_time/real_time_median",
+        "182",
+        "ms",
+        "183",
+        "ms",
+        "5",
+        "items_per_second=5.50302/s",
+    ]
+    assert res.get_unet_candidate_path() == "unet_candidate_12.vmfb"
     assert res.get_candidate_id() == 12
     assert res.get_device_id() == 24
     assert res.get_benchmark_time() == 182.0
 
     incomplete_str = "Benchmarking: unet_baseline.vmfb on device 24\n"
     res = autotune.UnetBenchmarkResult(incomplete_str)
-    assert res.get_tokens() == ['Benchmarking:', 'unet_baseline.vmfb', 'on', 'device', '24']
-    assert res.get_unet_candidate_path() == 'unet_baseline.vmfb'
+    assert res.get_tokens() == [
+        "Benchmarking:",
+        "unet_baseline.vmfb",
+        "on",
+        "device",
+        "24",
+    ]
+    assert res.get_unet_candidate_path() == "unet_baseline.vmfb"
     assert res.get_candidate_id() == None
     assert res.get_device_id() == 24
     assert res.get_benchmark_time() == None

--- a/tuning/tune.py
+++ b/tuning/tune.py
@@ -8,16 +8,16 @@ import logging
 import math
 import pickle
 import re
-import z3
+import z3 # type: ignore
 from dataclasses import asdict, dataclass
 from enum import Enum
 from os import mkdir, path, makedirs
 from typing import Callable
 from textwrap import indent
 
-import iree.compiler as ireec
-from iree.compiler import ir
-from iree.compiler.dialects import _linalg_ops_gen, _util_ops_gen
+import iree.compiler as ireec # type: ignore
+from iree.compiler import ir # type: ignore
+from iree.compiler.dialects import _linalg_ops_gen, _util_ops_gen # type: ignore
 
 """
 Usage: ./tune.py 121.mlir -o "tuning/candidates" -l 1024 --lhs-dims=mk --rhs-dims=nk --tile-dims=mnk


### PR DESCRIPTION
1. Rewrite some expression in `autotune.py` and add `assert` to pass mypy test
2. Use `# type: ignore` to resolve mypy missing-imports errors for now. May change `mypy.ini` in future for such issues.
3. Add new test for `res.get_*()` function of classes `DispatchBenchmarkResult` and `UnetBenchmarkResult`