### PR TITLE
[tuner] Combine multiple log files

### DIFF
--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -331,7 +331,7 @@ def validate_devices(user_devices: list[str]) -> None:
     for device in user_devices:
         handle_error(
             condition=(device not in available_devices),
-            msg=f"Invalid device specified: {device}",
+            msg=f"Invalid device specified: {device}\nFetched available devices: {available_devices}",
             error_type=argparse.ArgumentError,
             exit_program=True,
         )
@@ -1280,7 +1280,7 @@ def autotune(args: argparse.Namespace) -> None:
 
     print("Validating devices")
     validate_devices(args.devices)
-    print("Validation successful!")
+    print("Validation successful!\n")
 
     print("Generating candidates...")
     candidates = generate_candidates(args, path_config, candidate_trackers)

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -18,10 +18,8 @@ import hashlib
 from dataclasses import dataclass, field
 from typing import Type, Optional, Callable, Iterable, Any
 import pickle
-from itertools import groupby
 import iree.runtime as ireert
 import random
-import tempfile
 
 """
 Sample Usage:
@@ -905,6 +903,7 @@ def benchmark_compiled_candidates(
     logging.info("benchmark_top_candidates()")
 
     if args.dry_run:
+        logging.info("generate_dryrun_dispatch_benchmark_results")
         benchmark_results = generate_dryrun_dispatch_benchmark_results(
             compiled_candidates
         )
@@ -1150,6 +1149,7 @@ def parse_grouped_benchmark_results(
 def generate_dryrun_unet_benchmark_results(
     unet_vmfb_paths: list[Path],
 ) -> list[TaskResult]:
+    logging.info("generate_dryrun_unet_benchmark_results")
     task_results = []
     start = random.uniform(100.0, 500.0)
     device_id = 0

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -1282,6 +1282,18 @@ def benchmark_unet(
     )
 
 
+def summerize_top_candidates(
+    path_config: PathConfig, candidate_trackers: list[CandidateTracker]
+):
+    dump_list = []
+    for candidate in candidate_trackers:
+        if candidate.unet_benchmark_time is not None:
+            final_str = f"Candidate {candidate.candidate_id}:\nUnet benchmark time: {candidate.unet_benchmark_time} on device {candidate.unet_benchmark_device_id}\nDispatch benchmark time: {candidate.first_benchmark_time} on device {candidate.unet_benchmark_device_id}\nSpec file: {candidate.mlir_spec_path}\n\n"
+            dump_list.append(final_str)
+    with open(path_config.result_summary_log, "w") as file:
+        file.writelines(dump_list)
+
+
 def autotune(args: argparse.Namespace) -> None:
     path_config = PathConfig()
     path_config.base_dir.mkdir(parents=True, exist_ok=True)
@@ -1334,6 +1346,9 @@ def autotune(args: argparse.Namespace) -> None:
     print(f"Stored results in {path_config.output_unilog}")
     if stop_after_phase == ExecutionPhases.benchmark_unet_candidates:
         return
+
+    summerize_top_candidates(path_config, candidate_trackers)
+    print(f"Stored top candidates info in {path_config.result_summary_log}\n")
 
     with open(path_config.candidate_trackers_pkl, "wb") as file:
         pickle.dump(candidate_trackers, file)

--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -118,9 +118,7 @@ class PathConfig:
         )
         object.__setattr__(self, "compiled_dir", self.candidates_dir / "compiled")
         object.__setattr__(self, "compilefailed_dir", self.candidates_dir / "failed")
-        object.__setattr__(
-            self, "results_unilog", self.base_dir / "results.log"
-        )
+        object.__setattr__(self, "results_unilog", self.base_dir / "results.log")
         object.__setattr__(
             self, "candidate_trackers_pkl", self.base_dir / "candidate_trackers.pkl"
         )
@@ -665,19 +663,20 @@ def load_pickle(file_path: Path) -> list[Any]:
     with open(file_path, "rb") as file:
         loaded_array = pickle.load(file)
     return loaded_array
-    
 
-def prepend_to_file(filepath: str, new_content: str, title: str="") -> None:
-    '''Appending new contents to the top of a file is complex.
-    Since the estimated log file size is small, this simple handling function is efficient enough.'''
+
+def prepend_to_file(filepath: Path, new_content: str, title: str = "") -> None:
+    """Appending new contents to the top of a file is complex.
+    Since the estimated log file size is small, this simple handling function is efficient enough.
+    """
     # Read the existing content
-    with open(filepath, 'r') as file:
+    with open(filepath, "r") as file:
         existing_content = file.read()
 
-    title_str = "="*5 + f" {title} " + "="*5 + '\n' if title != "" else ""
+    title_str = "=" * 5 + f" {title} " + "=" * 5 + "\n" if title != "" else ""
     # Write the new content followed by the existing content
-    with open(filepath, 'w') as file:
-        file.write(title_str + new_content + '\n\n' + existing_content)
+    with open(filepath, "w") as file:
+        file.write(title_str + new_content + "\n\n" + existing_content)
 
 
 def generate_candidates(
@@ -938,7 +937,11 @@ def benchmark_compiled_candidates(
     ) = parse_dispatch_benchmark_results(
         path_config, benchmark_results, candidate_trackers
     )
-    prepend_to_file(path_config.results_unilog, ''.join(dispatch_benchmark_dump_list), title="All Dispatch Benchmark Results")
+    prepend_to_file(
+        path_config.results_unilog,
+        "".join(dispatch_benchmark_dump_list),
+        title="All Dispatch Benchmark Results",
+    )
 
     benchmarking_rate = (len(parsed_benchmark_results) / len(benchmark_results)) * 100
     logging.critical(
@@ -955,11 +958,13 @@ def benchmark_compiled_candidates(
     )[: args.num_unet_candidates]
     logging.critical(f"Selected top[{len(best_results)}]")
 
-    result_content = '\n'.join(
+    result_content = "\n".join(
         f"{result.benchmark_time_in_seconds}\t{result.candidate_mlir.as_posix()}\t{result.candidate_spec_mlir.as_posix()}"
         for result in best_results
     )
-    prepend_to_file(path_config.results_unilog, result_content, title="Top Candidates Results")
+    prepend_to_file(
+        path_config.results_unilog, result_content, title="Top Candidates Results"
+    )
 
 
 def compile_unet_candidates(
@@ -972,7 +977,7 @@ def compile_unet_candidates(
 
     task_list = []
     with path_config.results_unilog.open("r") as log_file:
-        next(log_file) # skip title
+        next(log_file)  # skip title
         for line in log_file:
             if line == "\n":
                 break
@@ -1184,7 +1189,9 @@ def dryrun_benchmark_unet(
         path_config, grouped_benchmark_results, candidate_trackers
     )
 
-    prepend_to_file(path_config.results_unilog, ''.join(dump_list), title="Unet Benchmark Results")
+    prepend_to_file(
+        path_config.results_unilog, "".join(dump_list), title="Unet Benchmark Results"
+    )
 
 
 def benchmark_unet(
@@ -1263,7 +1270,9 @@ def benchmark_unet(
         path_config, grouped_benchmark_results, candidate_trackers
     )
 
-    prepend_to_file(path_config.results_unilog, ''.join(dump_list), title="Unet Benchmark Results")
+    prepend_to_file(
+        path_config.results_unilog, "".join(dump_list), title="Unet Benchmark Results"
+    )
 
 
 def autotune(args: argparse.Namespace) -> None:
@@ -1300,9 +1309,7 @@ def autotune(args: argparse.Namespace) -> None:
     benchmark_compiled_candidates(
         args, path_config, compiled_candidates, candidate_trackers
     )
-    print(
-        f"Stored results in {path_config.results_unilog}\n"
-    )
+    print(f"Stored results in {path_config.results_unilog}\n")
 
     if stop_after_phase == ExecutionPhases.benchmark_candidates:
         return
@@ -1315,9 +1322,7 @@ def autotune(args: argparse.Namespace) -> None:
 
     print("Benchmarking unet candidates...")
     benchmark_unet(args, path_config, unet_candidates, candidate_trackers)
-    print(
-        f"Stored results in {path_config.results_unilog}"
-    )
+    print(f"Stored results in {path_config.results_unilog}")
     if stop_after_phase == ExecutionPhases.benchmark_unet_candidates:
         return
 

--- a/tuning/test_autotune.py
+++ b/tuning/test_autotune.py
@@ -213,6 +213,7 @@ def test_parse_dispatch_benchmark_results():
         time: float, i: int
     ) -> autotune.ParsedDisptachBenchmarkResult:
         return autotune.ParsedDisptachBenchmarkResult(
+            i,
             time,
             path_config.get_candidate_mlir_path(i),
             path_config.get_candidate_spec_mlir_path(i),
@@ -227,16 +228,29 @@ def test_parse_dispatch_benchmark_results():
         for i in random_order
     ]
 
-    candidate_trackers = [autotune.CandidateTracker(i) for i in range(total)]
-    candidate_trackers_before = [autotune.CandidateTracker(i) for i in range(total)]
+    path_config = autotune.PathConfig()
 
-    expect_candidate_trackers = [autotune.CandidateTracker(i) for i in range(total)]
+    candidate_trackers = [
+        autotune.CandidateTracker(i, mlir_path=path_config.get_candidate_mlir_path(i))
+        for i in range(total)
+    ]
+    candidate_trackers_before = [
+        autotune.CandidateTracker(i, mlir_path=path_config.get_candidate_mlir_path(i))
+        for i in range(total)
+    ]
+
+    expect_candidate_trackers = [
+        autotune.CandidateTracker(
+            i,
+            mlir_path=path_config.get_candidate_mlir_path(i),
+            mlir_spec_path=path_config.get_candidate_spec_mlir_path(i),
+        )
+        for i in range(total)
+    ]
     for i in range(total):
         expect_candidate_trackers[test_list[i][0]].first_benchmark_time = test_list[i][
             1
         ]
-
-    path_config = autotune.PathConfig()
 
     tmp = [generate_parsed_disptach_benchmark_result(t, i) for i, t in test_list]
     expect_parsed_results = [tmp[i] for i in random_order]
@@ -497,7 +511,7 @@ def test_validate_devices_with_invalid_device():
                 autotune.validate_devices(user_devices)
                 expected_call = call(
                     condition=True,
-                    msg=f"Invalid device specified: cuda://default",
+                    msg=f"Invalid device specified: cuda://default\nFetched available devices: ['hip://0', 'local-sync://default']",
                     error_type=argparse.ArgumentError,
                     exit_program=True,
                 )


### PR DESCRIPTION
Now there will be 3 logs generated by `autotune.py`

1. `autotune_###.log`: Provides a trace of the script's execution steps.
2. `output.log`: Captures outputs generated during the script run.
3. `result_summary.log`: Summarizes important info and spec contents of top candidates