### PR TITLE
[tuner] Convert compile_candidate.sh to py function compile_dispatch()

### DIFF
--- a/tuning/autotune.py
+++ b/tuning/autotune.py
@@ -144,6 +144,11 @@ class PathConfig:
         return f"./{path.as_posix()}"
 
 
+class CompilationMode(Enum):
+    DEFAULT = "default"
+    WINOGRAD = "winograd"
+
+
 @dataclass
 class TaskTuple:
     args: argparse.Namespace
@@ -353,7 +358,7 @@ def parse_arguments() -> argparse.Namespace:
 
     # Required arguments
     parser.add_argument(
-        "mode", choices=["default", "winograd"], help="Compilation mode"
+        "mode", choices=[m.value for m in CompilationMode], help="Compilation mode"
     )
     parser.add_argument(
         "input_file", type=Path, help="Path to the input benchmark file (.mlir)"

--- a/tuning/autotune_functions.py
+++ b/tuning/autotune_functions.py
@@ -1,0 +1,82 @@
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass
+class CompileDispatchTaskPack:
+    candidate_id: int
+    input_path_str: str
+    out_path_str: str
+    mode: str
+
+
+@dataclass
+class CompileDispatchResultPack:
+    candidate_id: int
+    success: bool
+
+
+def compile_dispatch(
+    compile_dispatch_task_pack: CompileDispatchTaskPack,
+) -> CompileDispatchResultPack:
+    candidate_id = compile_dispatch_task_pack.candidate_id
+    input_path_str = compile_dispatch_task_pack.input_path_str
+    out_path_str = compile_dispatch_task_pack.out_path_str
+    mode = compile_dispatch_task_pack.mode
+
+    try:
+        subprocess.run(
+            [
+                "timeout",
+                "4s",
+                "./punet.sh",
+                input_path_str,
+                "-o",
+                out_path_str,
+                "--compile-from=executable-sources",
+            ],
+            check=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        return CompileDispatchResultPack(success=False, candidate_id=candidate_id)
+
+    # Check for 'rocm-hsaco-fb' in the output
+    try:
+        result = subprocess.run(
+            ["tools/iree-dump-module", out_path_str],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        if "rocm-hsaco-fb" not in result.stdout:
+            raise RuntimeError
+    except (subprocess.CalledProcessError, RuntimeError):
+        return CompileDispatchResultPack(success=False, candidate_id=candidate_id)
+
+    # TODO: Add local logger to print this message
+    # print(f"Compiling {candidate_id}: success")
+    return CompileDispatchResultPack(success=True, candidate_id=candidate_id)
+
+
+def benchmark_dispatch():
+    # TODO
+    pass
+
+
+def compile_model():
+    # TODO
+    pass
+
+
+def benchmark_model():
+    # TODO
+    pass
+
+
+def main():
+    return
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Bash scripts will be converted as functions in `autotune_functions.py`
Each function will have a `TaskPack` and `ResultPack` as input and output


autotune_functions.py:
- `compile_dispatch()` compiles a single dispatch

autotune.py:
- Add class `CompilationMode` to replace the original list `['default', 'winograd']`
- Refactor `compile_candidates()`
- Edit var name and append new dir path in `PathConfig`
- Add `CompileDispatchResultPack` maker function
- Add function to write `#_spec.mlir` for candidates
