### PR TITLE
Cleanup punet flags, add placeholder spec for QPX tuning

### DIFF
--- a/int8-model/benchmark-unet.sh
+++ b/int8-model/benchmark-unet.sh
@@ -18,7 +18,7 @@ iree-benchmark-module \
   --parameters=model=${IRPA_PATH_PREFIX}/sdxl_unet_int8_dataset.irpa \
   --function=main \
   --input=1x4x128x128xf16 \
-  --input=1xsi32 \
+  --input=1xf16 \
   --input=2x64x2048xf16 \
   --input=2x1280xf16 \
   --input=2x6xf16 \

--- a/int8-model/specs/attention_and_matmul_spec_punet_mi300_qpx.mlir
+++ b/int8-model/specs/attention_and_matmul_spec_punet_mi300_qpx.mlir
@@ -1,0 +1,96 @@
+module attributes { transform.with_named_sequence } {
+//===----------------------------------------------------------------------===//
+// Tuning infra
+//===----------------------------------------------------------------------===//
+
+  transform.named_sequence @apply_op_config(%op: !transform.any_op {transform.readonly},
+                                            %config: !transform.any_param {transform.readonly}) {
+    transform.annotate %op "compilation_info" = %config : !transform.any_op, !transform.any_param
+    // transform.print %op {name = "Applied"} : !transform.any_op
+    transform.yield
+  }
+
+  transform.named_sequence @apply_attn_op_config(%attention: !transform.any_op {transform.readonly},
+                                                 %config: !transform.any_param {transform.readonly},
+                                                 %decomposition_config: !transform.any_param {transform.readonly}) {
+    transform.annotate %attention "compilation_info" = %config : !transform.any_op, !transform.any_param
+    transform.annotate %attention "decomposition_config" = %decomposition_config : !transform.any_op, !transform.any_param
+    // transform.print %attention {name = "Applied attention config"} : !transform.any_op
+    transform.yield
+  }
+
+//===----------------------------------------------------------------------===//
+// Attention tuning
+//===----------------------------------------------------------------------===//
+
+transform.named_sequence @match_attention_f16(%attention: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param, !transform.any_param) {
+    transform.match.operation_name %attention ["iree_linalg_ext.attention"] : !transform.any_op
+    %in0 = transform.get_operand %attention[0] : (!transform.any_op) -> !transform.any_value
+    transform.iree.match.cast_compatible_type %in0 = tensor<?x?x?x?xf16> : !transform.any_value
+
+    %config = transform.param.constant #iree_codegen.compilation_info<
+            lowering_config = #iree_gpu.lowering_config<{workgroup = [1, 1, 128, 0, 0, 0], reduction=[0, 0, 0, 0, 0, 64], promote_operands = [1, 2]}>,
+            translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+                                                              workgroup_size = [64, 4]
+                                                              subgroup_size = 64 ,
+              {llvm_func_attrs = { "amdgpu-waves-per-eu" = "2", "denormal-fp-math-f32" = "preserve-sign" }}>>
+    -> !transform.any_param
+
+    %decomposition_config = transform.param.constant {
+      qk_attrs = {attention_qk_matmul,
+                  lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.virtual_mma_layout<intrinsic = VMFMA_F32_32x32x16_F16>,
+                                                               subgroup_m_count = 4, subgroup_n_count = 1, promote_operands = [1] }>},
+      pv_attrs = {attention_pv_matmul,
+                  lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
+                                                               subgroup_m_count = 4, subgroup_n_count = 1, promote_operands = [1] }>}
+    } -> !transform.any_param
+
+    transform.yield %attention, %config, %decomposition_config : !transform.any_op, !transform.any_param, !transform.any_param
+  }
+
+transform.named_sequence @match_attention_f8(%attention: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param, !transform.any_param) {
+    transform.match.operation_name %attention ["iree_linalg_ext.attention"] : !transform.any_op
+    %in0 = transform.get_operand %attention[0] : (!transform.any_op) -> !transform.any_value
+    transform.iree.match.cast_compatible_type %in0 = tensor<?x?x?x?xf8E4M3FNUZ> : !transform.any_value
+
+    %config = transform.param.constant #iree_codegen.compilation_info<
+            lowering_config = #iree_gpu.lowering_config<{workgroup = [1, 1, 64, 0, 0, 0], reduction=[0, 0, 0, 0, 0, 64], promote_operands = [1, 2]}>,
+            translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+                                                              workgroup_size = [64, 4]
+                                                              subgroup_size = 64 ,
+              {llvm_func_attrs = { "amdgpu-waves-per-eu" = "2", "denormal-fp-math-f32" = "preserve-sign" }}>>
+    -> !transform.any_param
+
+    %decomposition_config = transform.param.constant {
+      qk_attrs = {attention_qk_matmul,
+                  lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>,
+                                                               subgroup_m_count = 4, subgroup_n_count = 1, promote_operands = [1] }>},
+      pv_attrs = {attention_pv_matmul,
+                  lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.virtual_mma_layout<intrinsic = VMFMA_F32_16x16x32_F8E4M3FNUZ>,
+                                                               subgroup_m_count = 4, subgroup_n_count = 1, promote_operands = [1] }>}
+    } -> !transform.any_param
+
+    transform.yield %attention, %config, %decomposition_config : !transform.any_op, !transform.any_param, !transform.any_param
+  }
+
+// TUNING_SPEC_BEGIN DO NOT REMOVE
+
+// TUNING_SPEC_END DO NOT REMOVE
+
+//===----------------------------------------------------------------------===//
+// Entry point
+//===----------------------------------------------------------------------===//
+
+  transform.named_sequence @__kernel_config(%variant_op: !transform.any_op {transform.consumed}) {
+    transform.foreach_match in %variant_op
+        // Attention.
+        @match_attention_f16 -> @apply_attn_op_config
+        , @match_attention_f8 -> @apply_attn_op_config
+
+        // TUNING_MATCH_BEGIN DO NOT REMOVE
+
+        // TUNING_MATCH_END DO NOT REMOVE
+      : (!transform.any_op) -> (!transform.any_op)
+    transform.yield
+  }
+} ////  module


### PR DESCRIPTION
Cleanup punet flags and add a placeholder spec for tuning on QPX. Also add an argument to compile-punet.sh for the chip configuration (for selecting the right tuning spec). Current tuning specs have no effect compared against default tile-and-fuse matmuls, so the placeholder spec has no tuning for matmuls yet.