### PR TITLE
[MI300X][QPX] Tune top 1 matmul for punet batch size 14

### DIFF
--- a/int8-model/specs/attention_and_matmul_spec_punet_mi300_qpx.mlir
+++ b/int8-model/specs/attention_and_matmul_spec_punet_mi300_qpx.mlir
@@ -75,6 +75,26 @@ transform.named_sequence @match_attention_f8(%attention: !transform.any_op {tran
 
 // TUNING_SPEC_BEGIN DO NOT REMOVE
 
+//===----------------------------------------------------------------------===//
+// Contraction Tuning for UNET Batch Size 14
+//===----------------------------------------------------------------------===//
+
+  transform.named_sequence @match_contraction_28672x10240x1280_i8xi8xi32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
+    ^bb0(%arg1: tensor<28672x1280xi8>, %arg2: tensor<10240x1280xi8>, %arg3: tensor<28672x10240xi32>):
+      %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<28672x1280xi8>, tensor<10240x1280xi8>) outs(%arg3 : tensor<28672x10240xi32>) {
+      ^bb0(%in: i8, %in_0: i8, %out: i32):
+        %2 = arith.extsi %in : i8 to i32
+        %3 = arith.extsi %in_0 : i8 to i32
+        %4 = arith.muli %2, %3 : i32
+        %5 = arith.addi %out, %4 : i32
+        linalg.yield %5 : i32
+      } -> tensor<28672x10240xi32>
+    } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+    %0 = transform.param.constant #iree_codegen.compilation_info<lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>, promote_operands = [0, 1], reduction = [0, 0, 2], subgroup = [4, 4, 0], subgroup_m_count = 4 : i64, subgroup_n_count = 2 : i64, workgroup = [256, 128, 0]}>, translation_info = <pipeline = LLVMGPUTileAndFuse workgroup_size = [512, 1, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>> -> !transform.any_param
+    transform.yield %arg0, %0 : !transform.any_op, !transform.any_param
+  }
+
 // TUNING_SPEC_END DO NOT REMOVE
 
 //===----------------------------------------------------------------------===//
@@ -86,6 +106,7 @@ transform.named_sequence @match_attention_f8(%attention: !transform.any_op {tran
         // Attention.
         @match_attention_f16 -> @apply_attn_op_config
         , @match_attention_f8 -> @apply_attn_op_config
+        , @match_contraction_28672x10240x1280_i8xi8xi32 -> @apply_op_config
 
         // TUNING_MATCH_BEGIN DO NOT REMOVE
 


### PR DESCRIPTION
Add tuning spec for top BS 14 matmul. Gives roughly `2%` perf improvement on punet for Mi300X QPX.