### PR TITLE
Rename iree-codegen-llvmgpu-test-tile-and-fuse-matmul flag

### DIFF
--- a/int8-model/compile-punet-base.sh
+++ b/int8-model/compile-punet-base.sh
@@ -50,7 +50,7 @@ set -x
     --iree-opt-strip-assertions \
     --iree-dispatch-creation-enable-aggressive-fusion \
     --iree-llvmgpu-enable-prefetch \
-    --iree-codegen-llvmgpu-test-tile-and-fuse-matmul=true \
+    --iree-codegen-llvmgpu-early-tile-and-fuse-matmul=true \
     --iree-codegen-gpu-native-math-precision=true \
     --iree-codegen-transform-dialect-library="$ATTENTION_SPEC" \
     "${FLAGS[@]}" \


### PR DESCRIPTION
Renames `iree-codegen-llvmgpu-test-tile-and-fuse-matmul` to `iree-codegen-llvmgpu-early-tile-and-fuse-matmul` after flag name changed in IREE.